### PR TITLE
Add copy/paste and undo/redo support

### DIFF
--- a/src/Attribute.cc
+++ b/src/Attribute.cc
@@ -73,7 +73,8 @@ namespace piper
     Attribute::~Attribute()
     {
         // Disconnect related links.
-        for (auto& link : links_)
+        QVector<Link*> linksCopy = links_; //Create a copy: links_ as the list is altered while looping
+        for (auto& link : linksCopy)
         {
             link->disconnect();
         }

--- a/src/AttributeMember.cc
+++ b/src/AttributeMember.cc
@@ -62,17 +62,16 @@ namespace piper
     {
         switch (data.type())
         {
-            case QVariant::Type::Int:
+            //QJsonValue always returns QVariant::Double with numbers
+            //send both signals, the widget with corresponding type will receive values
+            case QVariant::Int:
+            case QVariant::Double:
             {
                 form_->dataUpdated(data.toInt());
-                break;
-            }
-            case QVariant::Type::Double:
-            {
                 form_->dataUpdated(data.toDouble());
                 break;
             }
-            case QVariant::Type::String:
+            case QVariant::String:
             {
                 form_->dataUpdated(data.toString());
                 break;

--- a/src/JsonExport.cc
+++ b/src/JsonExport.cc
@@ -56,16 +56,15 @@ namespace piper
     void JsonExport::writeNode(QString const& type, QString const& name, QString const& stage, QHash<QString, QVariant> const& attributes)
     {
         QJsonObject node;
-        node["type"] = type;
-        node["stage"] = stage;
-
         for (auto it = attributes.constBegin(); it != attributes.constEnd(); ++it)
         {
-            if (it.key() == "type")  { qWarning() << "type is a reerved attribute. Skipping.";  continue; }
-            if (it.key() == "stage") { qWarning() << "stage is a reerved attribute. Skipping."; continue; }
+            if (it.key() == "type")  { qWarning() << "type is a reserved attribute. Skipping.";  continue; }
+            if (it.key() == "stage") { qWarning() << "stage is a reserved attribute. Skipping."; continue; }
             node[it.key()] = QJsonValue::fromVariant(it.value());
         }
 
+        node["type"] = type;
+        node["stage"] = stage;
         nodes_[name] = node;
     }
 

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -5,6 +5,7 @@
 #include <QStandardItemModel>
 #include <QVector>
 #include <QJsonObject>
+#include <QStack>
 
 namespace piper
 {
@@ -27,6 +28,10 @@ namespace piper
         void removeNode(Node* node);
         QVector<Node*> const& nodes() const { return nodes_; }
 
+        QByteArray copyCurrentScene();
+        void loadSceneFromStack(QStack<QByteArray> stack);
+        void undo();
+        void redo();
         void addLink(Link* link);
         void removeLink(Link* link);
         QVector<Link*> const& links() const { return links_; }
@@ -65,6 +70,9 @@ namespace piper
 
         QStandardItemModel* stages_;
         QStandardItemModel* modes_;
+
+        static QStack<QByteArray> undoStack_;
+        static QStack<QByteArray> redoStack_;
     };
 
     QDataStream& operator<<(QDataStream& out, Scene const& scene);

--- a/src/View.h
+++ b/src/View.h
@@ -2,6 +2,7 @@
 #define PIPER_VIEW_H
 
 #include <QGraphicsView>
+#include <QByteArray>
 
 
 namespace piper
@@ -26,10 +27,17 @@ namespace piper
         void mouseReleaseEvent(QMouseEvent *event) override;
 
     private:
+        void copy();
+        void paste();
+        void undo();
+        void redo();
+
         CreatorPopup* creator_;
         bool pan_{false};
         int panStartX_{};
         int panStartY_{};
+
+        static QByteArray copy_;
     };
 }
 


### PR DESCRIPTION
Add copy/paste support
Add undo/redo support
Fix: piper crash when a node is deleted with an attribute connected to at least 3 links
Fix: typo
