### PR TITLE
remove qt migration remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ for the conversion workflow.
 git clone <repo>
 cd Piper
 ./setup_build.sh build           # generates Conan profile + installs deps
-cmake -S . -B build
-cmake --build build -j
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 
 ./build/app/piper-editor examples/motor_control_simple.piper
 ```

--- a/app/canvas_adapter.cc
+++ b/app/canvas_adapter.cc
@@ -195,7 +195,7 @@ namespace piper::app
                 ImU32       pin_rgb  = to_imu32(c);
                 if (not active)
                 {
-                    pin_rgb = darken(pin_rgb, 0.5f);
+                    pin_rgb = darken(pin_rgb, theme_.pin_alpha_inactive);
                 }
 
                 canvas::Pin pin{};

--- a/app/include/piper/app/canvas_adapter.h
+++ b/app/include/piper/app/canvas_adapter.h
@@ -17,8 +17,8 @@
 namespace piper::app
 {
     // Bridges a piper::Graph + NodeRegistry into a canvas::Graph the
-    // editor can render. View-only at PR 4.2: rebuild() is called
-    // explicitly after host mutations.
+    // editor can render. rebuild() is called explicitly after host
+    // mutations.
     class PiperCanvasGraph : public canvas::Graph
     {
     public:

--- a/app/panels/inspector_panel.cc
+++ b/app/panels/inspector_panel.cc
@@ -111,8 +111,7 @@ namespace piper::app
             }
         }
 
-        // Mode label in the active profile. Direct mutation (no
-        // SetModeProfileCommand yet) -- see PR 4.7.
+        // Mode label in the active profile.
         if (not active_mode_profile.empty())
         {
             piper::ModeProfile const* active = nullptr;

--- a/canvas/include/piper/canvas/editor.h
+++ b/canvas/include/piper/canvas/editor.h
@@ -72,7 +72,7 @@ namespace piper::canvas
         void set_body_renderer(BodyRenderer const& renderer) { body_renderer_ = renderer; }
         void set_context_menu(ContextMenuFn const& menu)     { context_menu_  = menu; }
 
-        // Imperative API for host-driven view changes. PR 2.2+ implements.
+        // Imperative API for host-driven view changes.
         void   center_on(NodeId id);
         void   scroll_to(NodeId id);
         void   set_selection(std::span<NodeId const> ids);

--- a/core/include/piper/stage.h
+++ b/core/include/piper/stage.h
@@ -3,14 +3,11 @@
 
 #include <string>
 
-#include "piper/color.h"
-
 namespace piper
 {
     struct Stage
     {
         std::string name;
-        rgba        color{0xFFFFFFFFu};
     };
 }
 

--- a/core/src/serialize_v2.cc
+++ b/core/src/serialize_v2.cc
@@ -10,12 +10,10 @@
 #include <nlohmann/json.hpp>
 
 #include "piper/attribute.h"
-#include "piper/color.h"
 #include "piper/link.h"
 #include "piper/mode_profile.h"
 #include "piper/node.h"
 #include "piper/node_type.h"
-#include "piper/rgba_io.h"
 #include "piper/stage.h"
 
 #include "diagnostic_helpers.h"
@@ -196,8 +194,7 @@ namespace piper::v2
         for (auto const& s : g.stages())
         {
             json stage_json;
-            stage_json["name"]  = s.name;
-            stage_json["color"] = format_rgba(s.color);
+            stage_json["name"] = s.name;
             doc["stages"].push_back(stage_json);
         }
 
@@ -493,20 +490,6 @@ namespace piper::v2
                 }
                 Stage s;
                 s.name = stage_json.at("name").get<std::string>();
-                if (auto color_it = stage_json.find("color"); color_it != stage_json.end() and color_it->is_string())
-                {
-                    auto parsed = parse_rgba(color_it->get<std::string>());
-                    if (parsed.has_value())
-                    {
-                        s.color = *parsed;
-                    }
-                    else
-                    {
-                        // Stage's default color (opaque white) stays in effect.
-                        result.diagnostics.push_back(schema_error(
-                            "stage '" + s.name + "' has malformed color"));
-                    }
-                }
                 if (not result.graph.add_stage(s))
                 {
                     Diagnostic d;

--- a/examples/motor_control_dual_jacobian.piper
+++ b/examples/motor_control_dual_jacobian.piper
@@ -313,11 +313,9 @@
       ],
       "stages": [
         {
-          "color": "#FF6060FF",
           "name": "control"
         },
         {
-          "color": "#60FF60FF",
           "name": "feedback"
         }
       ]

--- a/examples/motor_control_simple.piper
+++ b/examples/motor_control_simple.piper
@@ -136,11 +136,9 @@
       ],
       "stages": [
         {
-          "color": "#FF6060FF",
           "name": "control"
         },
         {
-          "color": "#60FF60FF",
           "name": "feedback"
         }
       ]

--- a/migrate/include/piper/migrate/v1_reader.h
+++ b/migrate/include/piper/migrate/v1_reader.h
@@ -8,23 +8,14 @@
 
 namespace piper::migrate
 {
-    struct Options
-    {
-        // --strict upgrades reader warnings (orphan links, unknown
-        // mode labels, ...) into hard errors. Implemented in PR 3.4;
-        // honored here as a no-op until then.
-        bool strict = false;
-    };
-
     // Reads a V1-era pipeline JSON document and produces a bundle of
     // V2 pipelines (one per top-level key in the V1 document). Returns
     // structural drift (orphan links, unknown attributes, ...) through
     // the per-pipeline diagnostics. Throws std::runtime_error only on
     // malformed JSON or schema-level violations the reader cannot
     // recover from.
-    v2::BundleLoadResult read_v1(std::string_view             json,
-                                  NodeRegistry const&          registry,
-                                  Options const&               opts = {});
+    v2::BundleLoadResult read_v1(std::string_view    json,
+                                  NodeRegistry const& registry);
 }
 
 #endif

--- a/migrate/main.cc
+++ b/migrate/main.cc
@@ -121,13 +121,10 @@ int main(int argc, char* argv[])
     piper::NodeRegistry registry;
     piper::register_builtin_nodes(registry);
 
-    piper::migrate::Options opts;
-    opts.strict = strict;
-
     try
     {
         std::string const v1_json = read_file(input);
-        auto              bundle  = piper::migrate::read_v1(v1_json, registry, opts);
+        auto              bundle  = piper::migrate::read_v1(v1_json, registry);
 
         std::size_t total_diags     = bundle.diagnostics.size();
         std::size_t critical_diags  = 0;

--- a/migrate/src/v1_reader.cc
+++ b/migrate/src/v1_reader.cc
@@ -19,9 +19,9 @@ namespace piper::migrate
 {
     using nlohmann::json;
 
-    // V1 stored every attribute value as a stringified QVariant. The
-    // V2 in-memory model also keeps values as strings; the on-disk
-    // typing happens at serialize time.
+    // V1 stored every attribute value as a string. The V2 in-memory
+    // model also keeps values as strings; the on-disk typing happens
+    // at serialize time.
     std::string v1_value_to_string(json const& v)
     {
         if (v.is_string())
@@ -287,8 +287,7 @@ namespace piper::migrate
     }
 
     v2::BundleLoadResult read_v1(std::string_view     jsonstr,
-                                  NodeRegistry const& registry,
-                                  Options const&)
+                                  NodeRegistry const& registry)
     {
         json doc;
         try

--- a/py_bindings/src/piper_module.cc
+++ b/py_bindings/src/piper_module.cc
@@ -136,8 +136,7 @@ NB_MODULE(piper, m)
     // ---- Stage ----
     nb::class_<Stage>(m, "Stage")
         .def(nb::init<>())
-        .def_rw("name",  &Stage::name)
-        .def_rw("color", &Stage::color);
+        .def_rw("name",  &Stage::name);
 
     // ---- ModeProfile ----
     nb::class_<ModeProfile>(m, "ModeProfile")

--- a/tests/core/basic-t.cc
+++ b/tests/core/basic-t.cc
@@ -180,9 +180,9 @@ TEST(Graph, RemoveLinkUnknownIsNoop)
 TEST(Graph, AddStage)
 {
     Graph g;
-    EXPECT_TRUE(g.add_stage({ "control",  rgba{ 0xFF0000FFu } }));
-    EXPECT_TRUE(g.add_stage({ "feedback", rgba{ 0x00FF00FFu } }));
-    EXPECT_FALSE(g.add_stage({ "control",  rgba{ 0x0000FFFFu } }));
+    EXPECT_TRUE(g.add_stage({ "control" }));
+    EXPECT_TRUE(g.add_stage({ "feedback" }));
+    EXPECT_FALSE(g.add_stage({ "control" }));
     EXPECT_EQ(g.stages().size(), 2u);
 }
 
@@ -191,7 +191,7 @@ TEST(Graph, RemoveStageDoesNotCascadeToNodes)
     Graph g;
     auto adder = make_adder();
     auto a = g.add_node(adder, "a", "control", {});
-    g.add_stage({ "control", rgba{ 0xFF0000FFu } });
+    g.add_stage({ "control" });
 
     g.remove_stage("control");
     EXPECT_TRUE(g.stages().empty());
@@ -206,7 +206,7 @@ TEST(Graph, RemoveStageDoesNotCascadeToNodes)
 TEST(Graph, RemoveStageUnknownIsNoop)
 {
     Graph g;
-    g.add_stage({ "control", rgba{ 0xFF0000FFu } });
+    g.add_stage({ "control" });
     g.remove_stage("nope");
     EXPECT_EQ(g.stages().size(), 1u);
 }

--- a/tests/core/roundtrip-t.cc
+++ b/tests/core/roundtrip-t.cc
@@ -55,8 +55,8 @@ Graph build_motor_graph()
     g.add_link({ bus_id, "torque_cmd"  }, { flt_id, "in" }, "vec3");
     g.add_link({ flt_id, "out"         }, { bus_id, "torque_meas" }, "vec3");
 
-    g.add_stage({ "control",  rgba::from_components(0xFF, 0x00, 0x00, 0xFF) });
-    g.add_stage({ "feedback", rgba::from_components(0x00, 0xFF, 0x00, 0xFF) });
+    g.add_stage({ "control" });
+    g.add_stage({ "feedback" });
 
     ModeProfile p;
     p.name        = "default";
@@ -136,8 +136,7 @@ TEST(SerializeV2, RoundTripPreservesStages)
     ASSERT_EQ(loaded.graph.stages().size(), original.stages().size());
     for (std::size_t i = 0; i < original.stages().size(); ++i)
     {
-        EXPECT_EQ(original.stages()[i].name,  loaded.graph.stages()[i].name);
-        EXPECT_EQ(original.stages()[i].color, loaded.graph.stages()[i].color);
+        EXPECT_EQ(original.stages()[i].name, loaded.graph.stages()[i].name);
     }
 }
 

--- a/tests/core/undo-t.cc
+++ b/tests/core/undo-t.cc
@@ -691,9 +691,9 @@ TEST(CommandStack, MixedSequenceUndoRedo)
 TEST(StageCommands, AddRemovePreservePosition)
 {
     Graph g;
-    g.add_stage({ "first",  rgba{} });
-    g.add_stage({ "second", rgba{} });
-    g.add_stage({ "third",  rgba{} });
+    g.add_stage({ "first" });
+    g.add_stage({ "second" });
+    g.add_stage({ "third" });
 
     CommandStack stack;
     stack.push(std::make_unique<RemoveStageCommand>("second"), g);
@@ -712,9 +712,9 @@ TEST(StageCommands, AddRemovePreservePosition)
 TEST(StageCommands, MoveStageRevertsOrder)
 {
     Graph g;
-    g.add_stage({ "a", rgba{} });
-    g.add_stage({ "b", rgba{} });
-    g.add_stage({ "c", rgba{} });
+    g.add_stage({ "a" });
+    g.add_stage({ "b" });
+    g.add_stage({ "c" });
 
     CommandStack stack;
     // Top-to-bottom drop ("a" dropped onto "c"): a goes after c.
@@ -734,9 +734,9 @@ TEST(StageCommands, MoveStageRevertsOrder)
 TEST(StageCommands, MoveStageBottomToTopDropsBeforeTarget)
 {
     Graph g;
-    g.add_stage({ "a", rgba{} });
-    g.add_stage({ "b", rgba{} });
-    g.add_stage({ "c", rgba{} });
+    g.add_stage({ "a" });
+    g.add_stage({ "b" });
+    g.add_stage({ "c" });
 
     CommandStack stack;
     // Bottom-to-top drop ("c" dropped onto "a"): c goes before a.

--- a/tests/engine/build_smoke-t.cc
+++ b/tests/engine/build_smoke-t.cc
@@ -27,7 +27,7 @@ namespace piper_engine_test
         piper::register_builtin_nodes(nr);
 
         Graph g;
-        g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+        g.add_stage(piper::Stage{ "control" });
 
         auto const* cf = nr.find("constant<float>");
         auto const* lp = nr.find("low_pass<float>");

--- a/tests/engine/cycle-t.cc
+++ b/tests/engine/cycle-t.cc
@@ -25,7 +25,7 @@ TEST(EngineBuild, CycleIsDiagnosedWithOffendingLink)
     piper::register_builtin_nodes(nr);
 
     Graph g;
-    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
 
     auto const* lp = nr.find("low_pass<float>");
     auto a_id = g.add_node(*lp, "a", "control", Point{ 0.0f, 0.0f });
@@ -64,7 +64,7 @@ TEST(EngineBuild, SelfLoopIsRejectedAsCycle)
     piper::register_builtin_nodes(nr);
 
     Graph g;
-    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
 
     auto const* lp = nr.find("low_pass<float>");
     auto a_id = g.add_node(*lp, "a", "control", Point{ 0.0f, 0.0f });

--- a/tests/engine/declare_io_failure-t.cc
+++ b/tests/engine/declare_io_failure-t.cc
@@ -22,7 +22,7 @@ TEST(EngineBuild, MalformedMemberValueEmitsStepDeclareIoFailed)
     piper::register_builtin_nodes(nr);
 
     Graph g;
-    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
 
     auto const* cf = nr.find("constant<float>");
     auto cf_id = g.add_node(*cf, "src", "control", Point{ 0.0f, 0.0f });

--- a/tests/engine/external_io-t.cc
+++ b/tests/engine/external_io-t.cc
@@ -27,7 +27,7 @@ namespace piper_engine_test
         piper::register_builtin_nodes(nr);
 
         Graph g;
-        g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+        g.add_stage(piper::Stage{ "control" });
 
         auto const* in_t  = nr.find("external_input<float>");
         auto const* out_t = nr.find("external_output<float>");
@@ -99,7 +99,7 @@ TEST(EngineExternalIO, EmptyNameSkipsHalIndexButStillTicks)
     piper::register_builtin_nodes(nr);
 
     Graph g;
-    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
 
     auto const* cf    = nr.find("constant<float>");
     auto const* out_t = nr.find("external_output<float>");

--- a/tests/engine/missing_factory-t.cc
+++ b/tests/engine/missing_factory-t.cc
@@ -22,7 +22,7 @@ TEST(EngineBuild, MissingFactoryEmitsDiagnostic)
     piper::register_builtin_nodes(nr);
 
     Graph g;
-    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
 
     auto const* cf = nr.find("constant<float>");
     auto cf_id = g.add_node(*cf, "src", "control", Point{ 0.0f, 0.0f });

--- a/tests/engine/multi_stage_tick-t.cc
+++ b/tests/engine/multi_stage_tick-t.cc
@@ -60,8 +60,8 @@ namespace piper_engine_test
 TEST(EngineTick, PerPinStagesActivateStepInExtraStage)
 {
     Graph g;
-    g.add_stage(piper::Stage{ "control",  0xFFFFFFFFu });
-    g.add_stage(piper::Stage{ "feedback", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
+    g.add_stage(piper::Stage{ "feedback" });
 
     NodeType const counter = piper_engine_test::make_counter_meta();
     NodeType probe_meta;

--- a/tests/engine/single_stage_tick-t.cc
+++ b/tests/engine/single_stage_tick-t.cc
@@ -26,7 +26,7 @@ TEST(EngineTick, ConstantPropagatesThroughLowPass)
     piper::register_builtin_nodes(nr);
 
     Graph g;
-    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    g.add_stage(piper::Stage{ "control" });
 
     auto const* cf = nr.find("constant<float>");
     auto const* lp = nr.find("low_pass<float>");

--- a/tests/fixtures/build_motor_dual_jacobian.cc
+++ b/tests/fixtures/build_motor_dual_jacobian.cc
@@ -13,8 +13,8 @@ namespace piper::fixtures
         // measured pin lives only in the feedback stage via a
         // per-pin override -- this is the canonical Bus pattern
         // where one node's pins span multiple stages.
-        g.add_stage({ "control",  rgba::from_components(0xFF, 0x60, 0x60, 0xFF) });
-        g.add_stage({ "feedback", rgba::from_components(0x60, 0xFF, 0x60, 0xFF) });
+        g.add_stage({ "control" });
+        g.add_stage({ "feedback" });
 
         auto require = [&](char const* type_name)
         {

--- a/tests/fixtures/build_motor_simple.cc
+++ b/tests/fixtures/build_motor_simple.cc
@@ -8,8 +8,8 @@ namespace piper::fixtures
     {
         Graph g;
 
-        g.add_stage({ "control",  rgba::from_components(0xFF, 0x60, 0x60, 0xFF) });
-        g.add_stage({ "feedback", rgba::from_components(0x60, 0xFF, 0x60, 0xFF) });
+        g.add_stage({ "control" });
+        g.add_stage({ "feedback" });
 
         NodeType const* sin_wave = reg.find("sin_wave<float>");
         if (sin_wave == nullptr)


### PR DESCRIPTION
## Summary

  - Remove `Stage::color` - stored, serialized, and Python-exposed but never rendered in the ImGui app (Qt showed colored stage labels; ImGui has no equivalent UI). Updates serializer, Python bindings, all test fixtures, and regenerates example `.piper` files.
  - Fix `pin_alpha_inactive` in `Theme` being ignored - `canvas_adapter.cc` was hardcoding `0.5f` instead of reading `theme_.pin_alpha_inactive`.
  - Remove dead `Options::strict` scaffolding from the migrate tool - `read_v1` accepted the struct but never honored it (unnamed parameter). The CLI `--strict` flag still works as before via the check in `main.cc`.
  - Remove stale PR-number references from comments (`canvas_adapter.h`, `editor.h`, `inspector_panel.cc`) and other stale comments.
  - Remove Qt artifact from `v1_reader.cc` comment ("stringified QVariant").
  
## Test
- [ ] Test V1 migration