### PR TITLE
Various fixes and improvements across the whole project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GLFW system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorg-dev libgl1-mesa-dev libglu1-mesa-dev
+
+      - name: Install Python tooling
+        run: pip install "conan>=2.10" nanobind
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2/p
+          key: conan-${{ runner.os }}-${{ hashFiles('conan/conanfile.txt', 'conan/profile.txt.template') }}
+
+      - name: Set up build (Conan profile + dependencies)
+        run: ./setup_build.sh build
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_TOOLCHAIN_FILE=build/toolchain.cmake
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_PY_BINDINGS=ON
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  build-wheels:
+    name: Build Python wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    env:
+      CIBW_ARCHS: native
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags needed by tools/setup/version.sh
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.0
+        with:
+          output-dir: wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 *.dylib
 *.a
 imgui.ini
+/pid_demo.csv
+/pid_demo.png
 *.orig
 *.bak
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(piper)
+project(piper VERSION 0.0.0)
 
 if (SKBUILD AND NOT CMAKE_CI_BUILD)
     execute_process(
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/setup_build.sh" "${CMAKE_BINARY_DIR}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND_ERROR_IS_FATAL ANY)
 endif()
 
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_BINARY_DIR})
@@ -22,16 +23,18 @@ if (SKBUILD)
     set(BUILD_TESTS_DEFAULT       OFF)
     set(BUILD_PY_BINDINGS_DEFAULT ON)
     set(BUILD_APP_DEFAULT         OFF)
+    set(BUILD_EXAMPLES_DEFAULT    OFF)
 else()
     set(BUILD_TESTS_DEFAULT       ON)
     set(BUILD_PY_BINDINGS_DEFAULT OFF)
     set(BUILD_APP_DEFAULT         ON)
+    set(BUILD_EXAMPLES_DEFAULT    ON)
 endif()
 
 option(BUILD_TESTS        "Build tests"             ${BUILD_TESTS_DEFAULT})
 option(BUILD_PY_BINDINGS  "Build Python bindings"   ${BUILD_PY_BINDINGS_DEFAULT})
 option(BUILD_APP          "Build the editor app"    ${BUILD_APP_DEFAULT})
-option(BUILD_EXAMPLES     "Build example binaries"  ON)
+option(BUILD_EXAMPLES     "Build example binaries"  ${BUILD_EXAMPLES_DEFAULT})
 
 add_subdirectory(core)
 add_subdirectory(engine)
@@ -42,12 +45,16 @@ if (BUILD_EXAMPLES)
     add_subdirectory(examples/pid_demo)
 endif()
 
-if (BUILD_APP)
+# tests/ needs piper_canvas and piper_migrate even when the app is off
+if (BUILD_APP OR BUILD_TESTS)
     add_subdirectory(canvas)
+    add_subdirectory(migrate)
+endif()
+
+if (BUILD_APP)
     add_subdirectory(vendor/imgui_backends)
     add_subdirectory(vendor/implot)
     add_subdirectory(app)
-    add_subdirectory(migrate)
     add_subdirectory(examples/canvas_demo)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for the conversion workflow.
 git clone <repo>
 cd Piper
 ./setup_build.sh build           # generates Conan profile + installs deps
-cmake -S . -B build
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=build/toolchain.cmake -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 
 ./build/app/piper-editor examples/filter_demo/filter_demo.piper
@@ -64,13 +64,18 @@ Architecture details: see `docs/architecture.md`.
 ```
 canvas/         reusable ImGui node-editor framework
 core/           domain layer: graph data, JSON (de)serializer, command stack
+engine/         graph execution: step registry, topological scheduling
 app/            piper-editor binary (uses canvas + core)
 migrate/        V1 JSON import CLI
 py_bindings/    nanobind wheel exposing the domain layer to Python
 examples/       bundled .piper graphs
 data/           default theme.json
 docs/           architecture, format, walkthroughs
-tests/          gtest suites for core, canvas, fixtures
+tests/          gtest suites for core, engine, canvas, migrate, fixtures
+vendor/         vendored sources: ImGui GLFW/OpenGL backends, ImPlot
+tools/          setup scripts (compiler detection, versioning)
+cmake/          shared CMake modules and toolchain template
+conan/          Conan dependency list and profile template
 ```
 
 Per-subdir READMEs:
@@ -101,10 +106,11 @@ Per-subdir READMEs:
 
 ## Building
 
-Requires CMake 3.28, Conan 2.10+, a C++20 toolchain, and either GLFW
-system deps (Linux: `libxkbcommon-dev`, `libwayland-dev`, ...) or
-the equivalent on macOS / Windows. `setup_build.sh` generates a
-Conan profile and resolves dependencies.
+Requires CMake 3.28, Conan 2.10+, and a C++20 toolchain. Supported
+platforms: Linux (GCC) and macOS (apple-clang, universal binary).
+Windows is not supported. On Linux the GLFW system deps are needed
+(`xorg-dev`, `libxkbcommon-dev`, `libwayland-dev`, ...).
+`setup_build.sh` generates a Conan profile and resolves dependencies.
 
 ## Tests
 
@@ -113,13 +119,18 @@ cmake --build build
 ctest --test-dir build
 ```
 
-Two gtest binaries:
+Four gtest binaries plus the Python binding suite, all registered
+with CTest:
 
-- `build/tests/core/piper_core_test` -- 153 cases over the data
-  model, JSON round-trip, theme parsing, command stack, lints.
-- `build/tests/canvas/piper_canvas_test` -- 53 cases over the
-  framework's math (AABB, transform, hit-test, link routing, pin
-  layout, selection).
+- `build/tests/core/piper_core_test` -- data model, JSON
+  round-trip, theme parsing, command stack, lints.
+- `build/tests/engine/piper_engine_test` -- step registry, label
+  resolution, graph execution.
+- `build/tests/canvas/piper_canvas_test` -- the framework's math
+  (AABB, transform, hit-test, link routing, pin layout, selection).
+- `build/tests/migrate/piper_migrate_test` -- V1 JSON import.
+- `piper_py_bindings` -- Python `unittest` suite over the nanobind
+  module (when `BUILD_PY_BINDINGS=ON`).
 
 The canvas demo (`build/examples/canvas_demo/canvas_demo`) drives
 the framework over a tiny `DemoGraph` independent of `piper_core`

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -73,3 +73,5 @@ target_link_libraries(piper_editor PRIVATE
     portable-file-dialogs::portable-file-dialogs
 )
 set_target_properties(piper_editor PROPERTIES OUTPUT_NAME piper-editor)
+
+install(TARGETS piper_editor RUNTIME DESTINATION bin)

--- a/app/assets/licenses/imgui.txt
+++ b/app/assets/licenses/imgui.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2026 Omar Cornut
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/assets/licenses/implot.txt
+++ b/app/assets/licenses/implot.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Evan Pezent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/assets/licenses/nlohmann-json.txt
+++ b/app/assets/licenses/nlohmann-json.txt
@@ -1,0 +1,21 @@
+MIT License 
+
+Copyright (c) 2013-2022 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/autosave.cc
+++ b/app/autosave.cc
@@ -1,8 +1,13 @@
+#include <signal.h>
+#include <unistd.h>
+
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <string>
+#include <string_view>
 
 #include "piper/app/autosave.h"
 
@@ -38,13 +43,24 @@ namespace piper::studio
         {
             return;
         }
-        std::string const path = dir + "/session-" + std::to_string(doc.session_id) + ".piper";
+        // PID in the name keeps concurrent editors from clobbering
+        // each other's session-<n> files.
+        std::string const path = dir + "/session-" + std::to_string(::getpid())
+                               + "-" + std::to_string(doc.session_id) + ".piper";
         std::string const tmp  = path + ".tmp";
         std::string const json = piper::v2::serialize(doc.graph, doc.pipeline_name);
         {
             std::ofstream f(tmp);
-            if (not f.is_open() or not (f << json))
+            if (not f.is_open())
             {
+                return;
+            }
+            f << json;
+            f.flush();
+            if (not f)
+            {
+                // Don't let the rename clobber the previous good autosave.
+                std::filesystem::remove(tmp, ec);
                 return;
             }
         }
@@ -69,6 +85,30 @@ namespace piper::studio
         doc.autosave_path.clear();
     }
 
+    bool process_is_alive(long pid)
+    {
+        if (::kill(pid_t(pid), 0) != 0)
+        {
+            return false;
+        }
+        // kill(pid, 0) also succeeds for a zombie; read the proc state so a
+        // crashed-but-unreaped session's autosave is still offered.
+        std::ifstream status{"/proc/" + std::to_string(pid) + "/status"};
+        if (not status)
+        {
+            return true;
+        }
+        std::string line;
+        while (std::getline(status, line))
+        {
+            if (line.rfind("State:", 0) == 0)
+            {
+                return line.find('Z') == std::string::npos;
+            }
+        }
+        return true;
+    }
+
     std::vector<std::string> scan_autosave_dir()
     {
         std::vector<std::string> out;
@@ -84,10 +124,33 @@ namespace piper::studio
         }
         for (auto const& entry : std::filesystem::directory_iterator(dir, ec))
         {
-            if (entry.is_regular_file() and entry.path().extension() == ".piper")
+            if (not entry.is_regular_file()
+                or entry.path().extension() != ".piper")
             {
-                out.push_back(entry.path().string());
+                continue;
             }
+            // session-<pid>-<id>.piper: skip files still owned by a
+            // live process. Legacy session-<id>.piper (no pid part)
+            // is always offered.
+            std::string const stem = entry.path().stem().string();
+            constexpr std::string_view prefix = "session-";
+            if (stem.starts_with(prefix))
+            {
+                std::string const rest = stem.substr(prefix.size());
+                std::size_t const dash = rest.find('-');
+                if (dash != std::string::npos)
+                {
+                    char* end = nullptr;
+                    long const pid = std::strtol(rest.c_str(), &end, 10);
+                    if (pid > 0
+                        and end == rest.c_str() + dash
+                        and process_is_alive(pid))
+                    {
+                        continue;
+                    }
+                }
+            }
+            out.push_back(entry.path().string());
         }
         return out;
     }

--- a/app/include/piper/app/autosave.h
+++ b/app/include/piper/app/autosave.h
@@ -22,7 +22,9 @@ namespace piper::studio
 
     // Returns the list of `.piper` files currently sitting in the
     // autosave directory (typically leftover from a previous session
-    // that crashed before they could be cleaned up).
+    // that crashed before they could be cleaned up). Files whose
+    // session-<pid>-<id> name points at a still-running process are
+    // skipped.
     std::vector<std::string> scan_autosave_dir();
 }
 

--- a/app/include/piper/app/document.h
+++ b/app/include/piper/app/document.h
@@ -121,6 +121,22 @@ namespace piper::studio
         std::unique_ptr<piper::engine::Engine>     engine;
         bool                                       engine_running{false};
         std::size_t                                engine_built_revision{0};
+        // Hot-rebuild debounce: last revision seen by tick_engine_live
+        // and the ImGui time it changed. Rebuild fires only once the
+        // revision has been stable for a beat, so merged-command drags
+        // (which bump the revision every frame) don't wipe probe state.
+        std::size_t                                live_seen_revision{0};
+        double                                     live_revision_change_time{0.0};
+        // Parsed min/max of each external_input's slider, keyed by node
+        // id. Rebuilt lazily when command_stack.revision() changes so
+        // the Live panel doesn't re-parse attr strings every frame.
+        struct LiveRange
+        {
+            float lo{0.0f};
+            float hi{0.0f};
+        };
+        std::unordered_map<piper::NodeId, LiveRange> live_range_cache;
+        std::size_t                                live_range_cache_revision{std::size_t(-1)};
         // Per-tick capture of every external_output<float>'s latest
         // value, keyed by node id. Canvas body renderer reads it to
         // draw probe values inline.

--- a/app/main.cc
+++ b/app/main.cc
@@ -42,7 +42,12 @@ ImFont* try_load_bundled(ImGuiIO& io, std::string_view name, float px)
 void load_font(ImGuiIO& io, std::string const& path, float size, float dpi_scale)
 {
     io.Fonts->Clear();
-    float const px = size * dpi_scale;
+    float px = size * dpi_scale;
+    // A non-positive size asserts inside ImGui at the first text bake.
+    if (px <= 0.0f)
+    {
+        px = 16.0f;
+    }
     ImFont* loaded = nullptr;
 
     if (path.starts_with(kBundledPrefix))
@@ -90,8 +95,16 @@ int main(int argc, char** argv)
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 
     piper::studio::Settings const startup_settings = piper::studio::load_settings();
-    int const init_w = startup_settings.window_w.value_or(1280);
-    int const init_h = startup_settings.window_h.value_or(800);
+    int init_w = startup_settings.window_w.value_or(1280);
+    int init_h = startup_settings.window_h.value_or(800);
+    if (init_w < 1)
+    {
+        init_w = 1280;
+    }
+    if (init_h < 1)
+    {
+        init_h = 800;
+    }
     GLFWwindow* window = glfwCreateWindow(init_w, init_h, "Piper", nullptr, nullptr);
     if (window == nullptr)
     {

--- a/app/main_window.cc
+++ b/app/main_window.cc
@@ -1286,6 +1286,35 @@ namespace piper::studio
         // play().
         ImGui::TextUnformatted("Inputs");
         ImGui::Separator();
+        if (doc.live_range_cache_revision != doc.command_stack.revision())
+        {
+            doc.live_range_cache.clear();
+            doc.live_range_cache_revision = doc.command_stack.revision();
+        }
+        auto const slider_range = [&](Node const& n,
+                                      float default_lo,
+                                      float default_hi) -> Document::LiveRange
+        {
+            auto const it = doc.live_range_cache.find(n.id);
+            if (it != doc.live_range_cache.end())
+            {
+                return it->second;
+            }
+            Document::LiveRange r{ default_lo, default_hi };
+            char const* min_s = attr_value(n, "min");
+            char const* max_s = attr_value(n, "max");
+            if (*min_s != '\0')
+            {
+                try { r.lo = std::stof(min_s); } catch (...) {}
+            }
+            if (*max_s != '\0')
+            {
+                try { r.hi = std::stof(max_s); } catch (...) {}
+            }
+            if (r.hi <= r.lo) { r.hi = r.lo + 1.0f; }
+            doc.live_range_cache.emplace(n.id, r);
+            return r;
+        };
         bool any_input = false;
         for (auto const& n : doc.graph.nodes())
         {
@@ -1298,11 +1327,9 @@ namespace piper::studio
                 }
                 any_input = true;
                 float& val = doc.live_input_float[ext_name];
-                float lo = -1.0f;
-                float hi =  1.0f;
-                try { lo = std::stof(attr_value(n, "min")); } catch (...) {}
-                try { hi = std::stof(attr_value(n, "max")); } catch (...) {}
-                if (hi <= lo) { hi = lo + 1.0f; }
+                Document::LiveRange const r = slider_range(n, -1.0f, 1.0f);
+                float const lo = r.lo;
+                float const hi = r.hi;
                 ImGui::PushID(int(n.id));
                 ImGui::SetNextItemWidth(-FLT_MIN);
                 // SliderFloat: visible position within [lo, hi]; Ctrl+click
@@ -1320,10 +1347,9 @@ namespace piper::studio
                 }
                 any_input = true;
                 int32_t& val = doc.live_input_int[ext_name];
-                int lo = -100;
-                int hi =  100;
-                try { lo = std::stoi(attr_value(n, "min")); } catch (...) {}
-                try { hi = std::stoi(attr_value(n, "max")); } catch (...) {}
+                Document::LiveRange const r = slider_range(n, -100.0f, 100.0f);
+                int lo = int(r.lo);
+                int hi = int(r.hi);
                 if (hi <= lo) { hi = lo + 1; }
                 ImGui::PushID(int(n.id));
                 ImGui::SetNextItemWidth(-FLT_MIN);
@@ -1528,25 +1554,39 @@ namespace piper::studio
         // Hot-rebuild if the graph mutated since the last build. Step
         // state (integrals, filter histories) resets -- acceptable for
         // interactive tweaking; the user expects "tweak, see".
-        if (doc.command_stack.revision() != doc.engine_built_revision)
+        // Debounced: a merged-command drag bumps the revision every
+        // frame, so rebuild only once the revision has been stable for
+        // a beat (initial build on Run-toggle stays immediate).
+        std::size_t const rev = doc.command_stack.revision();
+        if (rev != doc.engine_built_revision)
         {
-            doc.engine = std::make_unique<piper::engine::Engine>();
-            auto const r = doc.engine->build(doc.graph, step_registry_);
-            if (not r.ok)
+            double const now = ImGui::GetTime();
+            if (rev != doc.live_seen_revision)
             {
-                std::string msg = "live engine rebuild failed:";
-                for (auto const& d : r.diagnostics)
-                {
-                    msg += "\n  - " + d.message;
-                }
-                push_toast(ToastLevel::Error, msg);
-                doc.engine.reset();
-                doc.engine_running = false;
-                return;
+                doc.live_seen_revision        = rev;
+                doc.live_revision_change_time = now;
             }
-            doc.engine_built_revision = doc.command_stack.revision();
-            doc.probe_latest.clear();
-            doc.probe_history.clear();
+            // The previous build keeps ticking until the rebuild fires.
+            if (now - doc.live_revision_change_time > 0.25)
+            {
+                doc.engine = std::make_unique<piper::engine::Engine>();
+                auto const r = doc.engine->build(doc.graph, step_registry_);
+                if (not r.ok)
+                {
+                    std::string msg = "live engine rebuild failed:";
+                    for (auto const& d : r.diagnostics)
+                    {
+                        msg += "\n  - " + d.message;
+                    }
+                    push_toast(ToastLevel::Error, msg);
+                    doc.engine.reset();
+                    doc.engine_running = false;
+                    return;
+                }
+                doc.engine_built_revision = rev;
+                doc.probe_latest.clear();
+                doc.probe_history.clear();
+            }
         }
 
         // Drive external_input<*> from the Live panel's slider state.
@@ -1565,7 +1605,20 @@ namespace piper::studio
             }
         }
 
-        doc.engine->play();
+        try
+        {
+            doc.engine->play();
+        }
+        catch (std::exception const& e)
+        {
+            // Same teardown as the Stop button so the next Run rebuilds.
+            doc.engine_running        = false;
+            doc.engine.reset();
+            doc.engine_built_revision = 0;
+            push_toast(ToastLevel::Error,
+                       std::string("engine error: ") + e.what());
+            return;
+        }
 
         // Capture every external_output<float>'s latest value for the
         // canvas body renderer + scrolling plot. Bounded history --
@@ -1578,7 +1631,7 @@ namespace piper::studio
                 continue;
             }
             auto const* step = doc.engine->step_for(n.id);
-            if (step == nullptr)
+            if (step == nullptr or not step->has_input("in"))
             {
                 continue;
             }
@@ -1590,8 +1643,9 @@ namespace piper::studio
                 h.push_back(v);
                 if (h.size() > live_history_max)
                 {
-                    h.erase(h.begin(),
-                            h.begin() + (h.size() - live_history_max));
+                    // Trim in bulk so the memmove amortizes.
+                    std::size_t const keep = live_history_max * 3 / 4;
+                    h.erase(h.begin(), h.end() - keep);
                 }
             }
             catch (std::exception const&)
@@ -1647,7 +1701,7 @@ namespace piper::studio
             if (stages_defined and n.stage.empty())
             {
                 Diagnostic d;
-                d.kind    = Diagnostic::Kind::SchemaError;
+                d.kind    = Diagnostic::Kind::Lint;
                 d.message = "node '" + n.name + "' has no stage";
                 d.node_id = n.id;
                 doc.lint_diagnostics.push_back(d);
@@ -1671,7 +1725,7 @@ namespace piper::studio
             if (any_io and not any_connected)
             {
                 Diagnostic d;
-                d.kind    = Diagnostic::Kind::SchemaError;
+                d.kind    = Diagnostic::Kind::Lint;
                 d.message = "node '" + n.name + "' is disconnected";
                 d.node_id = n.id;
                 doc.lint_diagnostics.push_back(d);
@@ -1706,7 +1760,7 @@ namespace piper::studio
                 if (connected.count({ n.id, a.name }) == 0)
                 {
                     Diagnostic d;
-                    d.kind      = Diagnostic::Kind::SchemaError;
+                    d.kind      = Diagnostic::Kind::Lint;
                     d.message   = "input '" + n.name + "." + a.name
                                 + "' has no source";
                     d.node_id   = n.id;
@@ -1724,7 +1778,7 @@ namespace piper::studio
                 and not mode_labels_advertised_by(n, registry_).empty())
             {
                 Diagnostic d;
-                d.kind    = Diagnostic::Kind::SchemaError;
+                d.kind    = Diagnostic::Kind::Lint;
                 d.message = "node '" + n.name + "' has no label in profile '"
                           + doc.active_mode_profile + "' -- it advertises "
                           "computational slots that won't dispatch";
@@ -1808,10 +1862,16 @@ namespace piper::studio
                 return false;
             }
             f << json;
+            f.flush();
             if (not f)
             {
                 std::fprintf(stderr, "write to %s failed\n",
                              tmp_path.string().c_str());
+                std::error_code wec;
+                std::filesystem::remove(tmp_path, wec);
+                push_toast(ToastLevel::Error,
+                           "Save failed: could not write "
+                               + tmp_path.filename().string());
                 return false;
             }
         }
@@ -2512,12 +2572,18 @@ namespace piper::studio
                 Label const* hovered_label = adoc.graph.find_label(hovered.v);
                 if (hovered_label != nullptr and not hovered_label->name.empty())
                 {
-                    std::string const target_name = hovered_label->name;
+                    std::set<uint64_t> cluster;
+                    for (auto const& lbl : adoc.graph.labels())
+                    {
+                        if (lbl.name == hovered_label->name)
+                        {
+                            cluster.insert(lbl.id);
+                        }
+                    }
                     ImDrawList* dl = ImGui::GetWindowDrawList();
                     for (auto const& cn : adoc.adapter.nodes())
                     {
-                        Label const* sibling = adoc.graph.find_label(cn.id.v);
-                        if (sibling == nullptr or sibling->name != target_name)
+                        if (cluster.count(cn.id.v) == 0)
                         {
                             continue;
                         }
@@ -3824,6 +3890,26 @@ namespace piper::studio
                             {
                                 data_type = a->data_type;
                             }
+                        }
+                    }
+                    // One driver per node input. Labels stay permissive
+                    // (the resolver reports cluster errors).
+                    if (doc.graph.find_label(to.node) == nullptr)
+                    {
+                        bool occupied = false;
+                        for (auto const& l : doc.graph.links())
+                        {
+                            if (l.to == to)
+                            {
+                                occupied = true;
+                                break;
+                            }
+                        }
+                        if (occupied)
+                        {
+                            push_toast(ToastLevel::Warn,
+                                       "input already connected -- delete the existing link first");
+                            break;
                         }
                     }
                     doc.command_stack.push(std::make_unique<CreateLinkCommand>(from, to, data_type), doc.graph);

--- a/app/panels/modes_panel.cc
+++ b/app/panels/modes_panel.cc
@@ -159,124 +159,133 @@ namespace piper::studio
                 profile_names.push_back(mp.name);
             }
 
-            for (auto const& node : graph.nodes())
+            // Rows are uniform height, so only the visible slice is
+            // submitted. An open cell combo closes if its row scrolls
+            // out of the clip range.
+            ImGuiListClipper clipper;
+            clipper.Begin(int(graph.nodes().size()));
+            while (clipper.Step())
             {
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-                ImGui::TextUnformatted(node.name.c_str());
-
-                ImGui::PushID(int(node.id));
-                int col = 1;
-                for (auto const& profile_name : profile_names)
+                for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row)
                 {
-                    ImGui::TableSetColumnIndex(col++);
-                    ImGui::PushID(profile_name.c_str());
+                    auto const& node = graph.nodes()[std::size_t(row)];
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    ImGui::TextUnformatted(node.name.c_str());
 
-                    piper::ModeProfile const* current_profile = nullptr;
-                    for (auto const& mp : graph.mode_profiles())
+                    ImGui::PushID(int(node.id));
+                    int col = 1;
+                    for (auto const& profile_name : profile_names)
                     {
-                        if (mp.name == profile_name)
+                        ImGui::TableSetColumnIndex(col++);
+                        ImGui::PushID(profile_name.c_str());
+
+                        piper::ModeProfile const* current_profile = nullptr;
+                        for (auto const& mp : graph.mode_profiles())
                         {
-                            current_profile = &mp;
-                            break;
-                        }
-                    }
-                    if (current_profile == nullptr)
-                    {
-                        ImGui::PopID();
-                        continue;
-                    }
-
-                    std::string current_label;
-                    auto const it = current_profile->per_node.find(node.id);
-                    if (it != current_profile->per_node.end())
-                    {
-                        current_label = it->second;
-                    }
-                    char const* cell_preview = "(unset)";
-                    if (not current_label.empty())
-                    {
-                        cell_preview = current_label.c_str();
-                    }
-
-                    ImGui::SetNextItemWidth(-FLT_MIN);
-                    if (ImGui::BeginCombo("##cell", cell_preview))
-                    {
-                        auto const apply_label = [&](std::string const& new_label)
-                        {
-                            stack.push(std::make_unique<SetNodeModeLabelCommand>(
-                                           profile_name, node.id, new_label),
-                                       graph);
-                            dirty = true;
-                        };
-
-                        char const* const builtins[] = { "enable", "disable" };
-                        for (char const* lbl : builtins)
-                        {
-                            bool const sel = (current_label == lbl);
-                            if (ImGui::Selectable(lbl, sel) and not sel)
+                            if (mp.name == profile_name)
                             {
-                                apply_label(lbl);
+                                current_profile = &mp;
+                                break;
                             }
                         }
-
-                        auto const advertised = mode_labels_advertised_by(node, registry);
-                        if (not advertised.empty())
+                        if (current_profile == nullptr)
                         {
-                            ImGui::Separator();
-                            ImGui::TextDisabled("from this node:");
-                            for (auto const& lbl : advertised)
+                            ImGui::PopID();
+                            continue;
+                        }
+
+                        std::string current_label;
+                        auto const it = current_profile->per_node.find(node.id);
+                        if (it != current_profile->per_node.end())
+                        {
+                            current_label = it->second;
+                        }
+                        char const* cell_preview = "(unset)";
+                        if (not current_label.empty())
+                        {
+                            cell_preview = current_label.c_str();
+                        }
+
+                        ImGui::SetNextItemWidth(-FLT_MIN);
+                        if (ImGui::BeginCombo("##cell", cell_preview))
+                        {
+                            auto const apply_label = [&](std::string const& new_label)
+                            {
+                                stack.push(std::make_unique<SetNodeModeLabelCommand>(
+                                               profile_name, node.id, new_label),
+                                           graph);
+                                dirty = true;
+                            };
+
+                            char const* const builtins[] = { "enable", "disable" };
+                            for (char const* lbl : builtins)
                             {
                                 bool const sel = (current_label == lbl);
-                                if (ImGui::Selectable(lbl.c_str(), sel) and not sel)
+                                if (ImGui::Selectable(lbl, sel) and not sel)
                                 {
                                     apply_label(lbl);
                                 }
                             }
-                        }
 
-                        bool theme_started = false;
-                        for (auto const& kv : theme.mode_colors)
-                        {
-                            if (kv.first == "enable" or kv.first == "disable")
-                            {
-                                continue;
-                            }
-                            if (not theme_started)
+                            auto const advertised = mode_labels_advertised_by(node, registry);
+                            if (not advertised.empty())
                             {
                                 ImGui::Separator();
-                                ImGui::TextDisabled("from theme:");
-                                theme_started = true;
+                                ImGui::TextDisabled("from this node:");
+                                for (auto const& lbl : advertised)
+                                {
+                                    bool const sel = (current_label == lbl);
+                                    if (ImGui::Selectable(lbl.c_str(), sel) and not sel)
+                                    {
+                                        apply_label(lbl);
+                                    }
+                                }
                             }
-                            bool const sel = (current_label == kv.first);
-                            if (ImGui::Selectable(kv.first.c_str(), sel) and not sel)
+
+                            bool theme_started = false;
+                            for (auto const& kv : theme.mode_colors)
                             {
-                                apply_label(kv.first);
+                                if (kv.first == "enable" or kv.first == "disable")
+                                {
+                                    continue;
+                                }
+                                if (not theme_started)
+                                {
+                                    ImGui::Separator();
+                                    ImGui::TextDisabled("from theme:");
+                                    theme_started = true;
+                                }
+                                bool const sel = (current_label == kv.first);
+                                if (ImGui::Selectable(kv.first.c_str(), sel) and not sel)
+                                {
+                                    apply_label(kv.first);
+                                }
                             }
+                            ImGui::Separator();
+                            if (ImGui::Selectable("(unset)", current_label.empty())
+                                and not current_label.empty())
+                            {
+                                apply_label(std::string{});
+                            }
+                            ImGui::Separator();
+                            ImGui::TextDisabled("custom (Enter to apply):");
+                            static char custom_buf[64] = {};
+                            ImGui::SetNextItemWidth(-FLT_MIN);
+                            if (ImGui::InputText("##custom_label", custom_buf, sizeof(custom_buf),
+                                                 ImGuiInputTextFlags_EnterReturnsTrue)
+                                and custom_buf[0] != '\0')
+                            {
+                                apply_label(std::string{ custom_buf });
+                                custom_buf[0] = '\0';
+                                ImGui::CloseCurrentPopup();
+                            }
+                            ImGui::EndCombo();
                         }
-                        ImGui::Separator();
-                        if (ImGui::Selectable("(unset)", current_label.empty())
-                            and not current_label.empty())
-                        {
-                            apply_label(std::string{});
-                        }
-                        ImGui::Separator();
-                        ImGui::TextDisabled("custom (Enter to apply):");
-                        static char custom_buf[64] = {};
-                        ImGui::SetNextItemWidth(-FLT_MIN);
-                        if (ImGui::InputText("##custom_label", custom_buf, sizeof(custom_buf),
-                                             ImGuiInputTextFlags_EnterReturnsTrue)
-                            and custom_buf[0] != '\0')
-                        {
-                            apply_label(std::string{ custom_buf });
-                            custom_buf[0] = '\0';
-                            ImGui::CloseCurrentPopup();
-                        }
-                        ImGui::EndCombo();
+                        ImGui::PopID();
                     }
                     ImGui::PopID();
                 }
-                ImGui::PopID();
             }
             ImGui::EndTable();
         }

--- a/app/settings.cc
+++ b/app/settings.cc
@@ -49,7 +49,12 @@ namespace piper::studio
             }
             if (auto it = doc.find("font_size"); it != doc.end() and it->is_number())
             {
-                out.font_size = it->get<float>();
+                // Mirror the UI drag range; out-of-range values assert
+                // in ImGui's font baking.
+                float size = it->get<float>();
+                if (size < 8.0f)  { size = 8.0f; }
+                if (size > 48.0f) { size = 48.0f; }
+                out.font_size = size;
             }
             if (auto it = doc.find("window_x"); it != doc.end() and it->is_number_integer())
             {
@@ -61,11 +66,21 @@ namespace piper::studio
             }
             if (auto it = doc.find("window_w"); it != doc.end() and it->is_number_integer())
             {
-                out.window_w = it->get<int>();
+                // < 1 would make every launch fail; leave unset so the
+                // caller's default applies.
+                int const w = it->get<int>();
+                if (w >= 1)
+                {
+                    out.window_w = w;
+                }
             }
             if (auto it = doc.find("window_h"); it != doc.end() and it->is_number_integer())
             {
-                out.window_h = it->get<int>();
+                int const h = it->get<int>();
+                if (h >= 1)
+                {
+                    out.window_h = h;
+                }
             }
             if (auto it = doc.find("recent_files"); it != doc.end() and it->is_array())
             {
@@ -149,6 +164,14 @@ namespace piper::studio
                 return;
             }
             out << doc.dump(2) << '\n';
+            out.flush();
+            if (not out)
+            {
+                std::fprintf(stderr, "settings: write to %s failed\n", tmp.c_str());
+                std::error_code wec;
+                std::filesystem::remove(tmp, wec);
+                return;
+            }
         }
         std::error_code rec;
         std::filesystem::rename(tmp, path, rec);

--- a/canvas/include/piper/canvas/cull.h
+++ b/canvas/include/piper/canvas/cull.h
@@ -35,6 +35,11 @@ namespace piper::canvas
         Aabb const&            viewport,
         LayoutMetrics const&   metrics);
 
+    // Overload over precomputed AABBs; returns indices into `aabbs`.
+    std::vector<std::size_t> cull_visible(
+        std::span<Aabb const> aabbs,
+        Aabb const&           viewport);
+
     // Canvas-space center of the i-th pin of the given kind on `node`.
     // Inputs are pinned to the node's left edge, outputs to the right.
     // Vertically: header_height + (i + 0.5) * pin_row_height.
@@ -42,6 +47,14 @@ namespace piper::canvas
                               PinKind kind,
                               std::size_t index,
                               LayoutMetrics const& metrics);
+
+    // Overload taking the node's precomputed node_aabb(); skips the
+    // text re-measure.
+    ImVec2 pin_center_in_node(Node const& node,
+                              PinKind kind,
+                              std::size_t index,
+                              LayoutMetrics const& metrics,
+                              Aabb const& aabb);
 
     struct BezierPoints
     {

--- a/canvas/include/piper/canvas/editor.h
+++ b/canvas/include/piper/canvas/editor.h
@@ -172,6 +172,10 @@ namespace piper::canvas
         // Rebuilt at the top of every draw() -- link rendering and
         // hit-testing look up pin centers by id here.
         std::unordered_map<PinId, PinLocation> pin_index_;
+        // Rebuilt every draw(), parallel to source_.nodes(): one
+        // node_aabb (and one text measure per label) per node per
+        // frame; cull, hit-test, and pin layout all read this.
+        std::vector<Aabb> node_aabbs_;
 
         Selection          selection_;
         // Snapshot of selection_ before a box-select drag started.

--- a/canvas/include/piper/canvas/hit_test.h
+++ b/canvas/include/piper/canvas/hit_test.h
@@ -24,6 +24,12 @@ namespace piper::canvas
                                         ImVec2 const&          point,
                                         LayoutMetrics const&   metrics);
 
+    // Overload over precomputed AABBs; aabbs[i] must be
+    // node_aabb(nodes[i]).
+    std::optional<NodeId> hit_test_node(std::span<Node const>  nodes,
+                                        std::span<Aabb const>  aabbs,
+                                        ImVec2 const&          point);
+
     // Indices into `nodes` whose AABB intersects `box` -- used by
     // box-select.
     std::vector<std::size_t> nodes_in_box(std::span<Node const>  nodes,
@@ -53,6 +59,14 @@ namespace piper::canvas
     // outputs are tested before inputs on each node -- matches typical
     // mouse-target intuition.
     std::optional<PinHit> hit_test_pin(std::span<Node const>  nodes,
+                                       ImVec2 const&          point,
+                                       LayoutMetrics const&   metrics,
+                                       float                  radius);
+
+    // Overload over precomputed AABBs; aabbs[i] must be
+    // node_aabb(nodes[i]).
+    std::optional<PinHit> hit_test_pin(std::span<Node const>  nodes,
+                                       std::span<Aabb const>  aabbs,
                                        ImVec2 const&          point,
                                        LayoutMetrics const&   metrics,
                                        float                  radius);

--- a/canvas/src/cull.cc
+++ b/canvas/src/cull.cc
@@ -125,22 +125,47 @@ namespace piper::canvas
         return result;
     }
 
+    std::vector<std::size_t> cull_visible(
+        std::span<Aabb const> aabbs,
+        Aabb const&           viewport)
+    {
+        std::vector<std::size_t> result;
+        result.reserve(aabbs.size());
+        for (std::size_t i = 0; i < aabbs.size(); ++i)
+        {
+            if (aabbs[i].intersects(viewport))
+            {
+                result.push_back(i);
+            }
+        }
+        return result;
+    }
+
     ImVec2 pin_center_in_node(Node const& node,
                               PinKind kind,
                               std::size_t index,
                               LayoutMetrics const& metrics)
     {
+        return pin_center_in_node(node, kind, index, metrics,
+                                  node_aabb(node, metrics));
+    }
+
+    ImVec2 pin_center_in_node(Node const& node,
+                              PinKind kind,
+                              std::size_t index,
+                              LayoutMetrics const& metrics,
+                              Aabb const& aabb)
+    {
         if (node.shape != Shape::Rect)
         {
             // Label pentagons hang their single pin on the flat edge
             // (opposite the chevron tip), centered on body mid-height.
-            Aabb const a     = node_aabb(node, metrics);
-            float const mid_y = (a.min.y + a.max.y) * 0.5f;
+            float const mid_y = (aabb.min.y + aabb.max.y) * 0.5f;
             if (node.shape == Shape::LabelIn)
             {
-                return ImVec2{ a.min.x, mid_y };
+                return ImVec2{ aabb.min.x, mid_y };
             }
-            return ImVec2{ a.max.x, mid_y };
+            return ImVec2{ aabb.max.x, mid_y };
         }
         float const y = node.pos.y
                       + metrics.header_height
@@ -149,7 +174,7 @@ namespace piper::canvas
         {
             return ImVec2{ node.pos.x, y };
         }
-        return ImVec2{ node.pos.x + node_total_width(node, metrics), y };
+        return ImVec2{ aabb.max.x, y };
     }
 
     BezierPoints link_bezier(ImVec2 const& a, ImVec2 const& b, float strength)

--- a/canvas/src/editor.cc
+++ b/canvas/src/editor.cc
@@ -97,9 +97,10 @@ namespace piper::canvas
                         Transform const& transform,
                         ImVec2 const& origin,
                         ImVec2 const& canvas_offset,
+                        Aabb const& node_box,
                         bool selected)
     {
-        Aabb local = node_aabb(node, metrics);
+        Aabb local = node_box;
         local.min.x += canvas_offset.x;
         local.min.y += canvas_offset.y;
         local.max.x += canvas_offset.x;
@@ -359,22 +360,32 @@ namespace piper::canvas
 
         ImVec2 const canvas_min = transform_.to_canvas(origin, origin);
         ImVec2 const canvas_max = transform_.to_canvas(br, origin);
-        float  const spacing    = style_.grid_spacing;
-        for (float x = std::floor(canvas_min.x / spacing) * spacing;
-             x < canvas_max.x;
-             x += spacing)
+        float        spacing    = style_.grid_spacing;
+        if (spacing > 0.0f and transform_.zoom > 0.0f)
         {
-            ImVec2 const a = transform_.to_screen({ x, canvas_min.y }, origin);
-            ImVec2 const b = transform_.to_screen({ x, canvas_max.y }, origin);
-            draw_list->AddLine(a, b, style_.grid_line);
-        }
-        for (float y = std::floor(canvas_min.y / spacing) * spacing;
-             y < canvas_max.y;
-             y += spacing)
-        {
-            ImVec2 const a = transform_.to_screen({ canvas_min.x, y }, origin);
-            ImVec2 const b = transform_.to_screen({ canvas_max.x, y }, origin);
-            draw_list->AddLine(a, b, style_.grid_line);
+            // Coarsen below ~12 screen px so min-zoom doesn't flood
+            // the draw list with near-touching lines.
+            constexpr float min_screen_spacing = 12.0f;
+            while (spacing * transform_.zoom < min_screen_spacing)
+            {
+                spacing *= 4.0f;
+            }
+            for (float x = std::floor(canvas_min.x / spacing) * spacing;
+                 x < canvas_max.x;
+                 x += spacing)
+            {
+                ImVec2 const a = transform_.to_screen({ x, canvas_min.y }, origin);
+                ImVec2 const b = transform_.to_screen({ x, canvas_max.y }, origin);
+                draw_list->AddLine(a, b, style_.grid_line);
+            }
+            for (float y = std::floor(canvas_min.y / spacing) * spacing;
+                 y < canvas_max.y;
+                 y += spacing)
+            {
+                ImVec2 const a = transform_.to_screen({ canvas_min.x, y }, origin);
+                ImVec2 const b = transform_.to_screen({ canvas_max.x, y }, origin);
+                draw_list->AddLine(a, b, style_.grid_line);
+            }
         }
 
         if (background_renderer_)
@@ -383,10 +394,19 @@ namespace piper::canvas
                                  transform_.zoom, transform_.pan);
         }
 
-        pin_index_.clear();
-        pin_index_.reserve(nodes.size() * 2);
+        node_aabbs_.clear();
+        node_aabbs_.reserve(nodes.size());
         for (auto const& n : nodes)
         {
+            node_aabbs_.push_back(node_aabb(n, layout_));
+        }
+
+        pin_index_.clear();
+        pin_index_.reserve(nodes.size() * 2);
+        for (std::size_t ni = 0; ni < nodes.size(); ++ni)
+        {
+            Node const& n   = nodes[ni];
+            Aabb const& box = node_aabbs_[ni];
             ImVec2 offset{ 0.0f, 0.0f };
             if (dragging_nodes_ and selection_.contains(n.id))
             {
@@ -394,7 +414,7 @@ namespace piper::canvas
             }
             for (std::size_t i = 0; i < n.inputs.size(); ++i)
             {
-                ImVec2 c = pin_center_in_node(n, PinKind::Input, i, layout_);
+                ImVec2 c = pin_center_in_node(n, PinKind::Input, i, layout_, box);
                 c.x += offset.x;
                 c.y += offset.y;
                 pin_index_[n.inputs[i].id] = PinLocation{
@@ -403,7 +423,7 @@ namespace piper::canvas
             }
             for (std::size_t i = 0; i < n.outputs.size(); ++i)
             {
-                ImVec2 c = pin_center_in_node(n, PinKind::Output, i, layout_);
+                ImVec2 c = pin_center_in_node(n, PinKind::Output, i, layout_, box);
                 c.x += offset.x;
                 c.y += offset.y;
                 pin_index_[n.outputs[i].id] = PinLocation{
@@ -413,6 +433,7 @@ namespace piper::canvas
         }
 
         float const link_thickness = style_.link_thickness * transform_.zoom;
+        Aabb const  screen_rect{ origin, br };
         for (auto const& link : source_.links())
         {
             auto const& from_it = pin_index_.find(link.from);
@@ -431,25 +452,49 @@ namespace piper::canvas
                 col       = style_.node_outline_selected;
                 thickness = link_thickness * 2.0f;
             }
+            // The curve stays inside its control-point hull; pad by
+            // half the stroke width plus AA fringe, skip when the
+            // padded box misses the viewport so off-screen links are
+            // never tessellated.
+            float const margin = thickness * 0.5f + 2.0f;
+            Aabb const  link_box{
+                ImVec2{
+                    std::min(std::min(bez.a.x, bez.b.x),
+                             std::min(bez.c1.x, bez.c2.x)) - margin,
+                    std::min(std::min(bez.a.y, bez.b.y),
+                             std::min(bez.c1.y, bez.c2.y)) - margin,
+                },
+                ImVec2{
+                    std::max(std::max(bez.a.x, bez.b.x),
+                             std::max(bez.c1.x, bez.c2.x)) + margin,
+                    std::max(std::max(bez.a.y, bez.b.y),
+                             std::max(bez.c1.y, bez.c2.y)) + margin,
+                },
+            };
+            if (not link_box.intersects(screen_rect))
+            {
+                continue;
+            }
             draw_list->AddBezierCubic(bez.a, bez.c1, bez.c2, bez.b, col, thickness);
         }
 
         Aabb const viewport{ canvas_min, canvas_max };
-        auto const visible = cull_visible(nodes, viewport, layout_);
+        auto const visible = cull_visible(node_aabbs_, viewport);
         for (auto idx : visible)
         {
             auto const& node     = nodes[idx];
+            Aabb const& node_box = node_aabbs_[idx];
             bool const  selected = selection_.contains(node.id);
             ImVec2      offset{ 0.0f, 0.0f };
             if (dragging_nodes_ and selected)
             {
                 offset = drag_delta_;
             }
-            draw_node_body(draw_list, node, style_, layout_, transform_, origin, offset, selected);
+            draw_node_body(draw_list, node, style_, layout_, transform_, origin, offset, node_box, selected);
 
             if (body_renderer_)
             {
-                Aabb local = node_aabb(node, layout_);
+                Aabb local = node_box;
                 local.min.x += offset.x;
                 local.min.y += offset.y;
                 local.max.x += offset.x;
@@ -467,7 +512,7 @@ namespace piper::canvas
 
             for (std::size_t i = 0; i < node.inputs.size(); ++i)
             {
-                ImVec2 c_canvas = pin_center_in_node(node, PinKind::Input, i, layout_);
+                ImVec2 c_canvas = pin_center_in_node(node, PinKind::Input, i, layout_, node_box);
                 c_canvas.x += offset.x;
                 c_canvas.y += offset.y;
                 ImVec2 const c_screen = transform_.to_screen(c_canvas, origin);
@@ -476,7 +521,7 @@ namespace piper::canvas
             }
             for (std::size_t i = 0; i < node.outputs.size(); ++i)
             {
-                ImVec2 c_canvas = pin_center_in_node(node, PinKind::Output, i, layout_);
+                ImVec2 c_canvas = pin_center_in_node(node, PinKind::Output, i, layout_, node_box);
                 c_canvas.x += offset.x;
                 c_canvas.y += offset.y;
                 ImVec2 const c_screen = transform_.to_screen(c_canvas, origin);
@@ -494,7 +539,7 @@ namespace piper::canvas
                 Pin const&   src_pin    = *src_it->second.pin;
 
                 float const r_hit       = pin_hit_radius();
-                auto const  target      = hit_test_pin(nodes, cursor_canvas, layout_, r_hit);
+                auto const  target      = hit_test_pin(nodes, node_aabbs_, cursor_canvas, layout_, r_hit);
 
                 ImVec2  end_canvas = cursor_canvas;
                 Connect status     = Connect::Allow;
@@ -590,7 +635,7 @@ namespace piper::canvas
         last_hovered_node_ = NodeId{};
         if (hovered)
         {
-            auto const hit = hit_test_node(nodes, cursor_canvas, layout_);
+            auto const hit = hit_test_node(nodes, node_aabbs_, cursor_canvas);
             if (hit.has_value())
             {
                 last_hovered_node_ = *hit;
@@ -686,7 +731,7 @@ namespace piper::canvas
 
         if (hovered and ImGui::IsMouseClicked(ImGuiMouseButton_Right))
         {
-            auto const hit       = hit_test_node(nodes, cursor_canvas, layout_);
+            auto const hit       = hit_test_node(nodes, node_aabbs_, cursor_canvas);
             context_menu_node_   = hit.value_or(invalid_node_id);
             context_menu_canvas_ = cursor_canvas;
 
@@ -708,7 +753,7 @@ namespace piper::canvas
             hovered and ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left);
         if (left_double_clicked)
         {
-            auto const hit = hit_test_node(nodes, cursor_canvas, layout_);
+            auto const hit = hit_test_node(nodes, node_aabbs_, cursor_canvas);
             EventPayload ev{};
             ev.kind = Event::DoubleClicked;
             ev.node = hit.value_or(invalid_node_id);
@@ -722,7 +767,7 @@ namespace piper::canvas
         {
             bool const shift   = ImGui::GetIO().KeyShift;
             float const r_hit  = pin_hit_radius();
-            auto const  pin_at = hit_test_pin(nodes, cursor_canvas, layout_, r_hit);
+            auto const  pin_at = hit_test_pin(nodes, node_aabbs_, cursor_canvas, layout_, r_hit);
 
             if (pin_at.has_value())
             {
@@ -735,7 +780,7 @@ namespace piper::canvas
             }
             else
             {
-                auto const node_hit = hit_test_node(nodes, cursor_canvas, layout_);
+                auto const node_hit = hit_test_node(nodes, node_aabbs_, cursor_canvas);
                 if (node_hit.has_value())
                 {
                     selected_link_ = invalid_link_id;
@@ -965,7 +1010,7 @@ namespace piper::canvas
         {
             box_current_canvas_ = cursor_canvas;
             Aabb const  box     = make_aabb(box_start_canvas_, box_current_canvas_);
-            auto const  hits    = nodes_in_box(nodes, box, layout_);
+            auto const  hits    = cull_visible(node_aabbs_, box);
 
             std::vector<NodeId> next;
             next.reserve(box_select_base_.size() + hits.size());
@@ -1014,7 +1059,7 @@ namespace piper::canvas
             {
                 Pin const& src_pin = *src_it->second.pin;
                 float const r_hit  = pin_hit_radius();
-                auto const  target = hit_test_pin(nodes, cursor_canvas, layout_, r_hit);
+                auto const  target = hit_test_pin(nodes, node_aabbs_, cursor_canvas, layout_, r_hit);
 
                 if (target.has_value()
                     and target->pin->id  != connect_from_pin_id_
@@ -1054,6 +1099,8 @@ namespace piper::canvas
 
         if (context_menu_ and ImGui::BeginPopup("##canvas_ctx"))
         {
+            // Host may rebuild the graph here: `nodes`, node_aabbs_,
+            // and pin_index_ must not be dereferenced after it returns.
             context_menu_(context_menu_node_, context_menu_canvas_);
             ImGui::EndPopup();
         }

--- a/canvas/src/hit_test.cc
+++ b/canvas/src/hit_test.cc
@@ -55,6 +55,20 @@ namespace piper::canvas
         return std::nullopt;
     }
 
+    std::optional<NodeId> hit_test_node(std::span<Node const>  nodes,
+                                        std::span<Aabb const>  aabbs,
+                                        ImVec2 const&          point)
+    {
+        for (std::size_t i = nodes.size(); i > 0; --i)
+        {
+            if (aabbs[i - 1].contains(point))
+            {
+                return nodes[i - 1].id;
+            }
+        }
+        return std::nullopt;
+    }
+
     std::vector<std::size_t> nodes_in_box(std::span<Node const>  nodes,
                                           Aabb const&            box,
                                           LayoutMetrics const&   metrics)
@@ -71,6 +85,47 @@ namespace piper::canvas
         return result;
     }
 
+    std::optional<PinHit> pin_hit_on_node(Node const&          node,
+                                          Aabb const&          aabb,
+                                          ImVec2 const&        point,
+                                          LayoutMetrics const& metrics,
+                                          float                radius_sq)
+    {
+        for (std::size_t j = 0; j < node.outputs.size(); ++j)
+        {
+            ImVec2 const c  = pin_center_in_node(node, PinKind::Output, j, metrics, aabb);
+            float const dx = point.x - c.x;
+            float const dy = point.y - c.y;
+            if (dx * dx + dy * dy <= radius_sq)
+            {
+                return PinHit{ node.id, &node.outputs[j], PinKind::Output, c };
+            }
+        }
+        for (std::size_t j = 0; j < node.inputs.size(); ++j)
+        {
+            ImVec2 const c  = pin_center_in_node(node, PinKind::Input, j, metrics, aabb);
+            float const dx = point.x - c.x;
+            float const dy = point.y - c.y;
+            if (dx * dx + dy * dy <= radius_sq)
+            {
+                return PinHit{ node.id, &node.inputs[j], PinKind::Input, c };
+            }
+        }
+        return std::nullopt;
+    }
+
+    // Pin centers always lie on the node AABB boundary or inside it,
+    // so a node whose radius-expanded AABB misses `point` has no pin
+    // within `radius`.
+    bool pin_hit_possible(Aabb const& aabb, ImVec2 const& point, float radius)
+    {
+        Aabb const expanded{
+            ImVec2{ aabb.min.x - radius, aabb.min.y - radius },
+            ImVec2{ aabb.max.x + radius, aabb.max.y + radius },
+        };
+        return expanded.contains(point);
+    }
+
     std::optional<PinHit> hit_test_pin(std::span<Node const>  nodes,
                                        ImVec2 const&          point,
                                        LayoutMetrics const&   metrics,
@@ -79,26 +134,39 @@ namespace piper::canvas
         float const r_sq = radius * radius;
         for (std::size_t i = nodes.size(); i > 0; --i)
         {
-            Node const& n = nodes[i - 1];
-            for (std::size_t j = 0; j < n.outputs.size(); ++j)
+            Node const& n    = nodes[i - 1];
+            Aabb const  aabb = node_aabb(n, metrics);
+            if (not pin_hit_possible(aabb, point, radius))
             {
-                ImVec2 const c  = pin_center_in_node(n, PinKind::Output, j, metrics);
-                float const dx = point.x - c.x;
-                float const dy = point.y - c.y;
-                if (dx * dx + dy * dy <= r_sq)
-                {
-                    return PinHit{ n.id, &n.outputs[j], PinKind::Output, c };
-                }
+                continue;
             }
-            for (std::size_t j = 0; j < n.inputs.size(); ++j)
+            auto const hit = pin_hit_on_node(n, aabb, point, metrics, r_sq);
+            if (hit.has_value())
             {
-                ImVec2 const c  = pin_center_in_node(n, PinKind::Input, j, metrics);
-                float const dx = point.x - c.x;
-                float const dy = point.y - c.y;
-                if (dx * dx + dy * dy <= r_sq)
-                {
-                    return PinHit{ n.id, &n.inputs[j], PinKind::Input, c };
-                }
+                return hit;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<PinHit> hit_test_pin(std::span<Node const>  nodes,
+                                       std::span<Aabb const>  aabbs,
+                                       ImVec2 const&          point,
+                                       LayoutMetrics const&   metrics,
+                                       float                  radius)
+    {
+        float const r_sq = radius * radius;
+        for (std::size_t i = nodes.size(); i > 0; --i)
+        {
+            if (not pin_hit_possible(aabbs[i - 1], point, radius))
+            {
+                continue;
+            }
+            auto const hit = pin_hit_on_node(nodes[i - 1], aabbs[i - 1],
+                                             point, metrics, r_sq);
+            if (hit.has_value())
+            {
+                return hit;
             }
         }
         return std::nullopt;

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -19,4 +19,8 @@ else()
     message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}. Only GCC, Clang, and AppleClang are supported: please add your definitions here.")
 endif()
 
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+# LTO archives are GIMPLE-only and unusable from a Conan package, so
+# keep IPO off when building the package.
+if (NOT CONAN_PACKAGE_BUILD)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/conan/profile.txt.template
+++ b/conan/profile.txt.template
@@ -4,7 +4,7 @@ arch=@ARCH_NAME@
 compiler=@COMPILER_NAME@
 compiler.version=@MAJOR_VERSION@
 compiler.libcxx=@LIBCXX_NAME@
-compiler.cppstd=17
+compiler.cppstd=20
 build_type=Release
 
 [options]

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
@@ -12,6 +13,21 @@ class PiperPackage(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     options = {"fPIC": [True, False]}
     default_options = {"fPIC": True}
+
+    def set_version(self):
+        # tools/setup/version.sh stamps the version into pyproject.toml; read it
+        # here so the Conan and Python packages share one source. An explicit
+        # --version on the CLI takes precedence.
+        if self.version:
+            return
+        self.version = "0.0.0"
+        pyproject = os.path.join(self.recipe_folder, "pyproject.toml")
+        with open(pyproject, encoding="utf-8") as f:
+            for line in f:
+                match = re.match(r'\s*version\s*=\s*"v?([^"]+)"', line)
+                if match:
+                    self.version = match.group(1)
+                    break
 
     def export_sources(self):
         root = self.recipe_folder
@@ -49,19 +65,8 @@ class PiperPackage(ConanFile):
         cmake.build()
 
     def package(self):
-        # No install() rules exist for core/engine, so hand-copy the
-        # public headers and the static archives
-        for subdir in ("core/include", "engine/include"):
-            copy(self, "*.h",
-                 os.path.join(self.source_folder, subdir),
-                 os.path.join(self.package_folder, "include"))
-            copy(self, "*.tpp",
-                 os.path.join(self.source_folder, subdir),
-                 os.path.join(self.package_folder, "include"))
-        copy(self, "*.a",
-             self.build_folder,
-             os.path.join(self.package_folder, "lib"),
-             keep_path=False)
+        cmake = CMake(self)
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "piper")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,3 +19,9 @@ add_library(piper_core STATIC ${PIPER_CORE_SRCS})
 target_include_directories(piper_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(piper_core PRIVATE nlohmann_json::nlohmann_json)
 set_target_properties(piper_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Wheels (SKBUILD) install only the Python module.
+if (NOT SKBUILD)
+    install(TARGETS piper_core ARCHIVE DESTINATION lib)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include)
+endif()

--- a/core/include/piper/commands.h
+++ b/core/include/piper/commands.h
@@ -214,6 +214,7 @@ namespace piper
 
     private:
         Stage stage_;
+        bool  added_{false};
     };
 
     class RemoveStageCommand : public Command
@@ -457,6 +458,7 @@ namespace piper
 
     private:
         ModeProfile profile_;
+        bool        added_{false};
     };
 
     class RemoveModeProfileCommand : public Command

--- a/core/include/piper/diagnostic.h
+++ b/core/include/piper/diagnostic.h
@@ -32,6 +32,7 @@ namespace piper
             // Not an error -- emitted only when the file already
             // disagreed with the invariant.
             LabelClusterRepaired,
+            Lint,                       // advisory editor lint; nothing was skipped
         };
 
         Kind        kind;

--- a/core/include/piper/registry.h
+++ b/core/include/piper/registry.h
@@ -1,6 +1,8 @@
 #ifndef PIPER_REGISTRY_H
 #define PIPER_REGISTRY_H
 
+#include <cstddef>
+#include <functional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -43,14 +45,24 @@ namespace piper
         // the type is unknown.
         std::string_view library_of(std::string_view type_name) const;
 
-        // Pointers are valid only until the next add() call.
+        // Pointers remain valid for the registry's lifetime.
         std::vector<NodeType const*> all() const;
 
         std::size_t size() const { return types_.size(); }
         bool empty() const       { return types_.empty(); }
 
     private:
-        std::unordered_map<std::string, NodeType>   types_;
+        struct TypeNameHash
+        {
+            using is_transparent = void;
+            std::size_t operator()(std::string_view s) const
+            {
+                return std::hash<std::string_view>{}(s);
+            }
+        };
+
+        std::unordered_map<std::string, NodeType,
+                           TypeNameHash, std::equal_to<>> types_;
         std::unordered_map<std::string, std::string> library_of_;
     };
 }

--- a/core/include/piper/serialize_v2.h
+++ b/core/include/piper/serialize_v2.h
@@ -13,8 +13,11 @@
 
 namespace piper::v2
 {
+    // Additive fields do not bump these versions; bump only for breaking changes.
     constexpr int format_version = 3;
     constexpr int min_supported_version = 2;
+    constexpr int registry_format_version = 3;
+    constexpr int registry_min_supported_version = 2;
 
     // ---- Graph bundle (one or many pipelines) ----
 

--- a/core/src/builtin_nodes.cc
+++ b/core/src/builtin_nodes.cc
@@ -112,7 +112,7 @@ namespace piper
         nt.type     = typed_node_name<T>("probe");
         nt.category = "probe";
         nt.help     = std::string("Inspection sink for a ") + data_type_string<T>()
-                    + " signal (no engine impl).";
+                    + " signal.";
         nt.attributes = {
             { "in", data_type_string<T>(), AttributeSpec::Role::Input, "" },
         };
@@ -433,7 +433,7 @@ namespace piper
         reg.add("io", make_external_output<double>());
         reg.add("io", make_external_output<int32_t>());
 
-        // ---- example: nodes with no engine impl ----
+        // ---- example ----
         reg.add("example", make_probe<float>());
         reg.add("example", make_probe<int32_t>());
         reg.add("example", make_jacobian_2x2());

--- a/core/src/commands.cc
+++ b/core/src/commands.cc
@@ -356,12 +356,17 @@ namespace piper
 
     void AddStageCommand::apply(Graph& g)
     {
-        g.add_stage(stage_);
+        added_ = g.add_stage(stage_);
     }
 
     void AddStageCommand::revert(Graph& g)
     {
-        g.remove_stage(stage_.name);
+        // Duplicate-name apply was a no-op; don't delete the
+        // pre-existing stage.
+        if (added_)
+        {
+            g.remove_stage(stage_.name);
+        }
     }
 
     void RemoveStageCommand::apply(Graph& g)
@@ -824,12 +829,17 @@ namespace piper
 
     void AddModeProfileCommand::apply(Graph& g)
     {
-        g.add_mode_profile(profile_);
+        added_ = g.add_mode_profile(profile_);
     }
 
     void AddModeProfileCommand::revert(Graph& g)
     {
-        g.remove_mode_profile(profile_.name);
+        // Duplicate-name apply was a no-op; don't delete the
+        // pre-existing profile.
+        if (added_)
+        {
+            g.remove_mode_profile(profile_.name);
+        }
     }
 
     void RemoveModeProfileCommand::apply(Graph& g)

--- a/core/src/graph.cc
+++ b/core/src/graph.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <limits>
 
 #include "piper/graph.h"
 
@@ -34,6 +35,7 @@ namespace piper
 
     bool Graph::insert_node(Node const& node)
     {
+        if (node.id == invalid_node_id) { return false; }
         // Nodes and Labels share the NodeId space; reject collisions
         // with either kind so loaders can't produce ambiguous lookups.
         if (find_node(node.id) != nullptr or find_label(node.id) != nullptr)
@@ -96,6 +98,7 @@ namespace piper
 
     bool Graph::insert_link(Link const& link)
     {
+        if (link.id == invalid_link_id) { return false; }
         if (find_link(link.id) != nullptr)
         {
             return false;
@@ -455,13 +458,29 @@ namespace piper
 
     void Graph::reserve_ids_above(NodeId max_node_id, LinkId max_link_id)
     {
+        // Saturate at the type max so the counter never wraps to the
+        // invalid id 0.
         if (max_node_id >= next_node_id_)
         {
-            next_node_id_ = max_node_id + 1;
+            if (max_node_id == std::numeric_limits<NodeId>::max())
+            {
+                next_node_id_ = max_node_id;
+            }
+            else
+            {
+                next_node_id_ = max_node_id + 1;
+            }
         }
         if (max_link_id >= next_link_id_)
         {
-            next_link_id_ = max_link_id + 1;
+            if (max_link_id == std::numeric_limits<LinkId>::max())
+            {
+                next_link_id_ = max_link_id;
+            }
+            else
+            {
+                next_link_id_ = max_link_id + 1;
+            }
         }
     }
 
@@ -469,7 +488,14 @@ namespace piper
     {
         if (id >= next_annotation_id_)
         {
-            next_annotation_id_ = id + 1;
+            if (id == std::numeric_limits<AnnotationId>::max())
+            {
+                next_annotation_id_ = id;
+            }
+            else
+            {
+                next_annotation_id_ = id + 1;
+            }
         }
     }
 
@@ -674,18 +700,19 @@ namespace piper
     std::size_t Graph::repair_label_clusters()
     {
         std::size_t changed = 0;
-        for (std::size_t i = 0; i < labels_.size(); ++i)
+        for (auto& l : labels_)
         {
-            Label const& canonical = labels_[i];
-            if (canonical.name.empty()) { continue; }
-            for (std::size_t j = i + 1; j < labels_.size(); ++j)
+            if (l.name.empty()) { continue; }
+            // Canonical member is the smallest id in the cluster.
+            Label const* canonical = &l;
+            for (auto const& other : labels_)
             {
-                Label& other = labels_[j];
-                if (other.name != canonical.name) { continue; }
-                if (other.color == canonical.color) { continue; }
-                other.color = canonical.color;
-                ++changed;
+                if (other.name != l.name) { continue; }
+                if (other.id < canonical->id) { canonical = &other; }
             }
+            if (l.color == canonical->color) { continue; }
+            l.color = canonical->color;
+            ++changed;
         }
         return changed;
     }

--- a/core/src/registry.cc
+++ b/core/src/registry.cc
@@ -38,7 +38,7 @@ namespace piper
 
     NodeType const* NodeRegistry::find(std::string_view type_name) const
     {
-        auto it = types_.find(std::string(type_name));
+        auto it = types_.find(type_name);
         if (it == types_.end())
         {
             return nullptr;

--- a/core/src/serialize_v2.cc
+++ b/core/src/serialize_v2.cc
@@ -290,7 +290,15 @@ namespace piper::v2
         }
         try
         {
-            out.id    = node_json.at("id").get<NodeId>();
+            json const& id_json = node_json.at("id");
+            if (not id_json.is_number_unsigned()
+                or id_json.get<NodeId>() == invalid_node_id)
+            {
+                diags.push_back(schema_error(
+                    "node 'id' must be a positive integer"));
+                return false;
+            }
+            out.id    = id_json.get<NodeId>();
             out.type  = node_json.at("type").get<std::string>();
             out.name  = node_json.value("name",  std::string{});
             out.stage = node_json.value("stage", std::string{});
@@ -361,7 +369,15 @@ namespace piper::v2
         }
         try
         {
-            out.id = link_json.at("id").get<LinkId>();
+            json const& id_json = link_json.at("id");
+            if (not id_json.is_number_unsigned()
+                or id_json.get<LinkId>() == invalid_link_id)
+            {
+                diags.push_back(schema_error(
+                    "link 'id' must be a positive integer"));
+                return false;
+            }
+            out.id = id_json.get<LinkId>();
             out.from.node = link_json.at("from").at("node").get<NodeId>();
             out.from.attr = link_json.at("from").at("attr").get<std::string>();
             out.to.node   = link_json.at("to").at("node").get<NodeId>();
@@ -527,20 +543,29 @@ namespace piper::v2
                     continue;
                 }
                 Stage s;
-                s.name = stage_json.at("name").get<std::string>();
-                if (auto color_it = stage_json.find("color"); color_it != stage_json.end() and color_it->is_string())
+                try
                 {
-                    auto parsed = parse_rgba(color_it->get<std::string>());
-                    if (parsed.has_value())
+                    s.name = stage_json.at("name").get<std::string>();
+                    if (auto color_it = stage_json.find("color"); color_it != stage_json.end() and color_it->is_string())
                     {
-                        s.color = *parsed;
+                        auto parsed = parse_rgba(color_it->get<std::string>());
+                        if (parsed.has_value())
+                        {
+                            s.color = *parsed;
+                        }
+                        else
+                        {
+                            // Stage's default color (opaque white) stays in effect.
+                            result.diagnostics.push_back(schema_error(
+                                "stage '" + s.name + "' has malformed color"));
+                        }
                     }
-                    else
-                    {
-                        // Stage's default color (opaque white) stays in effect.
-                        result.diagnostics.push_back(schema_error(
-                            "stage '" + s.name + "' has malformed color"));
-                    }
+                }
+                catch (json::exception const& e)
+                {
+                    result.diagnostics.push_back(schema_error(
+                        std::string("stage parse error: ") + e.what()));
+                    continue;
                 }
                 if (not result.graph.add_stage(s))
                 {
@@ -611,6 +636,77 @@ namespace piper::v2
                     d.message = "duplicate node id " + std::to_string(node.id);
                     d.node_id = node.id;
                     result.diagnostics.push_back(d);
+                }
+            }
+        }
+
+        // Labels must load before links: a link whose endpoint is a
+        // first-class label would otherwise be dropped as orphaned.
+        if (auto it = doc.find("labels"); it != doc.end() and it->is_array())
+        {
+            for (auto const& lj : *it)
+            {
+                Label l;
+                if (not lj.contains("id"))
+                {
+                    result.diagnostics.push_back(schema_error("label missing 'id'"));
+                    continue;
+                }
+                try
+                {
+                    json const& id_json = lj.at("id");
+                    if (not id_json.is_number_unsigned()
+                        or id_json.get<LabelId>() == invalid_label_id)
+                    {
+                        result.diagnostics.push_back(schema_error(
+                            "label 'id' must be a positive integer"));
+                        continue;
+                    }
+                    l.id = id_json.get<LabelId>();
+                    std::string kind_str{"in"};
+                    if (auto kit = lj.find("kind"); kit != lj.end() and kit->is_string())
+                    {
+                        kind_str = kit->get<std::string>();
+                    }
+                    l.kind = LabelKind::In;
+                    if (kind_str == "out") { l.kind = LabelKind::Out; }
+                    if (auto nit = lj.find("name"); nit != lj.end() and nit->is_string())
+                    {
+                        l.name = nit->get<std::string>();
+                    }
+                    if (auto pit = lj.find("pos"); pit != lj.end() and pit->is_array() and pit->size() == 2)
+                    {
+                        l.pos.x = pit->at(0).get<float>();
+                        l.pos.y = pit->at(1).get<float>();
+                    }
+                    if (auto cit = lj.find("color"); cit != lj.end() and cit->is_string())
+                    {
+                        auto parsed = parse_rgba(cit->get<std::string>());
+                        if (parsed.has_value())
+                        {
+                            l.color = *parsed;
+                        }
+                        else
+                        {
+                            result.diagnostics.push_back(schema_error(
+                                "label '" + l.name + "' has malformed color"));
+                        }
+                    }
+                }
+                catch (json::exception const& e)
+                {
+                    result.diagnostics.push_back(schema_error(
+                        std::string("label parse error: ") + e.what()));
+                    continue;
+                }
+                if (max_node_id < l.id)
+                {
+                    max_node_id = l.id;
+                }
+                if (not result.graph.insert_label(l))
+                {
+                    result.diagnostics.push_back(schema_error(
+                        "duplicate label id " + std::to_string(l.id)));
                 }
             }
         }
@@ -746,32 +842,41 @@ namespace piper::v2
                     continue;
                 }
                 ModeProfile m;
-                m.name = mode_json.at("name").get<std::string>();
-
-                if (auto pn_it = mode_json.find("per_node"); pn_it != mode_json.end() and pn_it->is_array())
+                try
                 {
-                    for (auto const& entry : *pn_it)
-                    {
-                        if (not entry.contains("node") or not entry.contains("label"))
-                        {
-                            result.diagnostics.push_back(schema_error(
-                                "mode profile '" + m.name + "' per_node entry missing 'node' or 'label'"));
-                            continue;
-                        }
-                        NodeId nid       = entry.at("node").get<NodeId>();
-                        std::string label = entry.at("label").get<std::string>();
+                    m.name = mode_json.at("name").get<std::string>();
 
-                        if (result.graph.find_node(nid) == nullptr)
+                    if (auto pn_it = mode_json.find("per_node"); pn_it != mode_json.end() and pn_it->is_array())
+                    {
+                        for (auto const& entry : *pn_it)
                         {
-                            Diagnostic d;
-                            d.kind    = Diagnostic::Kind::OrphanModeReference;
-                            d.message = "mode profile '" + m.name + "' references unknown node "
-                                        + std::to_string(nid);
-                            d.node_id = nid;
-                            result.diagnostics.push_back(d);
+                            if (not entry.contains("node") or not entry.contains("label"))
+                            {
+                                result.diagnostics.push_back(schema_error(
+                                    "mode profile '" + m.name + "' per_node entry missing 'node' or 'label'"));
+                                continue;
+                            }
+                            NodeId nid       = entry.at("node").get<NodeId>();
+                            std::string label = entry.at("label").get<std::string>();
+
+                            if (result.graph.find_node(nid) == nullptr)
+                            {
+                                Diagnostic d;
+                                d.kind    = Diagnostic::Kind::OrphanModeReference;
+                                d.message = "mode profile '" + m.name + "' references unknown node "
+                                            + std::to_string(nid);
+                                d.node_id = nid;
+                                result.diagnostics.push_back(d);
+                            }
+                            m.per_node[nid] = label;
                         }
-                        m.per_node[nid] = label;
                     }
+                }
+                catch (json::exception const& e)
+                {
+                    result.diagnostics.push_back(schema_error(
+                        std::string("mode profile parse error: ") + e.what()));
+                    continue;
                 }
 
                 if (not result.graph.add_mode_profile(m))
@@ -792,36 +897,50 @@ namespace piper::v2
             for (auto const& an : *it)
             {
                 Annotation a;
-                if (an.contains("id"))
-                {
-                    a.id = an.at("id").get<AnnotationId>();
-                }
-                if (a.id == invalid_annotation_id)
+                if (not an.contains("id"))
                 {
                     result.diagnostics.push_back(schema_error("annotation missing 'id'"));
                     continue;
                 }
-                if (auto pit = an.find("pos"); pit != an.end() and pit->is_array() and pit->size() == 2)
+                try
                 {
-                    a.pos.x = pit->at(0).get<float>();
-                    a.pos.y = pit->at(1).get<float>();
-                }
-                if (auto sit = an.find("size"); sit != an.end() and sit->is_array() and sit->size() == 2)
-                {
-                    a.size.x = sit->at(0).get<float>();
-                    a.size.y = sit->at(1).get<float>();
-                }
-                if (auto cit = an.find("color"); cit != an.end() and cit->is_string())
-                {
-                    auto parsed = parse_rgba(cit->get<std::string>());
-                    if (parsed.has_value())
+                    json const& id_json = an.at("id");
+                    if (not id_json.is_number_unsigned()
+                        or id_json.get<AnnotationId>() == invalid_annotation_id)
                     {
-                        a.color = *parsed;
+                        result.diagnostics.push_back(schema_error(
+                            "annotation 'id' must be a positive integer"));
+                        continue;
+                    }
+                    a.id = id_json.get<AnnotationId>();
+                    if (auto pit = an.find("pos"); pit != an.end() and pit->is_array() and pit->size() == 2)
+                    {
+                        a.pos.x = pit->at(0).get<float>();
+                        a.pos.y = pit->at(1).get<float>();
+                    }
+                    if (auto sit = an.find("size"); sit != an.end() and sit->is_array() and sit->size() == 2)
+                    {
+                        a.size.x = sit->at(0).get<float>();
+                        a.size.y = sit->at(1).get<float>();
+                    }
+                    if (auto cit = an.find("color"); cit != an.end() and cit->is_string())
+                    {
+                        auto parsed = parse_rgba(cit->get<std::string>());
+                        if (parsed.has_value())
+                        {
+                            a.color = *parsed;
+                        }
+                    }
+                    if (auto tit = an.find("text"); tit != an.end() and tit->is_string())
+                    {
+                        a.text = tit->get<std::string>();
                     }
                 }
-                if (auto tit = an.find("text"); tit != an.end() and tit->is_string())
+                catch (json::exception const& e)
                 {
-                    a.text = tit->get<std::string>();
+                    result.diagnostics.push_back(schema_error(
+                        std::string("annotation parse error: ") + e.what()));
+                    continue;
                 }
                 if (a.id > max_annotation_id)
                 {
@@ -831,61 +950,6 @@ namespace piper::v2
                 {
                     result.diagnostics.push_back(schema_error(
                         "duplicate annotation id " + std::to_string(a.id)));
-                }
-            }
-        }
-
-        if (auto it = doc.find("labels"); it != doc.end() and it->is_array())
-        {
-            for (auto const& lj : *it)
-            {
-                Label l;
-                if (lj.contains("id"))
-                {
-                    l.id = lj.at("id").get<LabelId>();
-                }
-                if (l.id == invalid_label_id)
-                {
-                    result.diagnostics.push_back(schema_error("label missing 'id'"));
-                    continue;
-                }
-                std::string kind_str{"in"};
-                if (auto kit = lj.find("kind"); kit != lj.end() and kit->is_string())
-                {
-                    kind_str = kit->get<std::string>();
-                }
-                l.kind = LabelKind::In;
-                if (kind_str == "out") { l.kind = LabelKind::Out; }
-                if (auto nit = lj.find("name"); nit != lj.end() and nit->is_string())
-                {
-                    l.name = nit->get<std::string>();
-                }
-                if (auto pit = lj.find("pos"); pit != lj.end() and pit->is_array() and pit->size() == 2)
-                {
-                    l.pos.x = pit->at(0).get<float>();
-                    l.pos.y = pit->at(1).get<float>();
-                }
-                if (auto cit = lj.find("color"); cit != lj.end() and cit->is_string())
-                {
-                    auto parsed = parse_rgba(cit->get<std::string>());
-                    if (parsed.has_value())
-                    {
-                        l.color = *parsed;
-                    }
-                    else
-                    {
-                        result.diagnostics.push_back(schema_error(
-                            "label '" + l.name + "' has malformed color"));
-                    }
-                }
-                if (max_node_id < l.id)
-                {
-                    max_node_id = l.id;
-                }
-                if (not result.graph.insert_label(l))
-                {
-                    result.diagnostics.push_back(schema_error(
-                        "duplicate label id " + std::to_string(l.id)));
                 }
             }
         }
@@ -925,7 +989,17 @@ namespace piper::v2
             throw std::runtime_error(std::string("malformed JSON: ") + e.what());
         }
 
-        int version = doc.value("version", 0);
+        if (not doc.is_object())
+        {
+            throw std::runtime_error("malformed document: top level is not an object");
+        }
+        auto version_it = doc.find("version");
+        if (version_it == doc.end() or not version_it->is_number_integer())
+        {
+            throw std::runtime_error(
+                "malformed document: 'version' missing or not an integer");
+        }
+        int version = version_it->get<int>();
         // Loader accepts versions in [min_supported_version,
         // format_version]. v2 -> v3: labels were promoted from
         // label_in/label_out node entries to first-class Label
@@ -942,8 +1016,13 @@ namespace piper::v2
         BundleLoadResult result;
 
         auto pipelines_it = doc.find("pipelines");
-        if (pipelines_it != doc.end() and pipelines_it->is_array())
+        if (pipelines_it != doc.end())
         {
+            if (not pipelines_it->is_array())
+            {
+                throw std::runtime_error(
+                    "malformed document: 'pipelines' is not an array");
+            }
             for (auto const& pipeline_json : *pipelines_it)
             {
                 if (not pipeline_json.is_object())
@@ -986,7 +1065,7 @@ namespace piper::v2
     std::string serialize_registry(NodeRegistry const& reg)
     {
         json doc;
-        doc["version"] = format_version;
+        doc["version"] = registry_format_version;
         doc["types"]   = json::array();
 
         // Sort by type name so output is stable across runs.
@@ -1078,13 +1157,24 @@ namespace piper::v2
             throw std::runtime_error(std::string("malformed JSON: ") + e.what());
         }
 
-        int version = doc.value("version", 0);
-        if (version < min_supported_version or version > format_version)
+        if (not doc.is_object())
+        {
+            throw std::runtime_error("malformed document: top level is not an object");
+        }
+        auto version_it = doc.find("version");
+        if (version_it == doc.end() or not version_it->is_number_integer())
         {
             throw std::runtime_error(
-                "unsupported V2 format version " + std::to_string(version)
-                + " (supported: " + std::to_string(min_supported_version)
-                + ".." + std::to_string(format_version) + ")");
+                "malformed document: 'version' missing or not an integer");
+        }
+        int version = version_it->get<int>();
+        if (version < registry_min_supported_version
+            or version > registry_format_version)
+        {
+            throw std::runtime_error(
+                "unsupported registry format version " + std::to_string(version)
+                + " (supported: " + std::to_string(registry_min_supported_version)
+                + ".." + std::to_string(registry_format_version) + ")");
         }
 
         RegistryLoadResult result;

--- a/core/src/theme.cc
+++ b/core/src/theme.cc
@@ -117,7 +117,16 @@ namespace piper
             if (auto grid_it = canvas_it->find("grid"); grid_it != canvas_it->end() and grid_it->is_object())
             {
                 parse_color_field(*grid_it, "color", t.grid_line, result.diagnostics);
-                t.grid_spacing = grid_it->value("spacing", t.grid_spacing);
+                float const spacing = grid_it->value("spacing", t.grid_spacing);
+                if (spacing > 0.0f)
+                {
+                    t.grid_spacing = spacing;
+                }
+                else
+                {
+                    result.diagnostics.push_back(schema_error(
+                        "grid 'spacing' must be > 0"));
+                }
             }
         }
 
@@ -140,7 +149,22 @@ namespace piper
         if (auto font_it = doc.find("font"); font_it != doc.end() and font_it->is_object())
         {
             t.font_path = font_it->value("path", t.font_path);
-            t.font_size = font_it->value("size", t.font_size);
+            float size = font_it->value("size", t.font_size);
+            // Negated form so NaN also lands in the clamp branch.
+            if (not (size >= 8.0f and size <= 96.0f))
+            {
+                result.diagnostics.push_back(schema_error(
+                    "font 'size' out of range [8, 96]; clamped"));
+                if (size < 8.0f)
+                {
+                    size = 8.0f;
+                }
+                else
+                {
+                    size = 96.0f;
+                }
+            }
+            t.font_size = size;
         }
 
         if (auto types_it = doc.find("types"); types_it != doc.end() and types_it->is_object())

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,3 +11,9 @@ target_include_directories(piper_engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inclu
 target_include_directories(piper_engine PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(piper_engine PUBLIC piper_core)
 set_target_properties(piper_engine PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Wheels (SKBUILD) install only the Python module.
+if (NOT SKBUILD)
+    install(TARGETS piper_engine ARCHIVE DESTINATION lib)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include)
+endif()

--- a/engine/include/piper/engine/diagnostic.h
+++ b/engine/include/piper/engine/diagnostic.h
@@ -19,6 +19,10 @@ namespace piper::engine
             UnknownStageOnPin,     // pin lists a stage that the graph does not own
             NodeNeverScheduled,    // active_stages is empty
             StepDeclareIoFailed,   // declare_io() threw (e.g. malformed member value)
+            MissingInput,          // Required input pin has no wired producer
+            DuplicateInputWiring,  // two links target the same input pin
+            StepConstructionFailed,// factory threw while constructing the step
+            FactoryTypeMismatch,   // external IO node's step is not the engine's Input/Output type
         };
 
         Kind          kind{Kind::UnresolvedInput};

--- a/engine/include/piper/engine/engine.h
+++ b/engine/include/piper/engine/engine.h
@@ -3,10 +3,10 @@
 
 #include <cstddef>
 #include <stdint.h>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "piper/graph.h"
@@ -24,6 +24,15 @@ namespace piper::engine
     class Engine
     {
     public:
+        Engine() = default;
+
+        // IoBlock::current_mode, Step::io_ and stage_data_ all point
+        // into this object; copying or moving would leave them dangling.
+        Engine(Engine const&)            = delete;
+        Engine& operator=(Engine const&) = delete;
+        Engine(Engine&&)                 = delete;
+        Engine& operator=(Engine&&)      = delete;
+
         struct BuildResult
         {
             bool                          ok{false};
@@ -56,16 +65,27 @@ namespace piper::engine
         Mode current_mode() const { return current_mode_; }
 
         // External I/O lookup: resolve once at HAL setup, then call
-        // set()/get() on the returned pointer in the hot path. The
+        // set()/get() on the returned pointer in the hot path. The raw
         // pointer is non-owning and stays valid until the next build().
         // Returns nullptr if no external_input<T> / external_output<T>
         // node with that "name" Member exists in the graph.
         template<typename T> step::Input<T>*        input (std::string_view name);
         template<typename T> step::Output<T> const* output(std::string_view name) const;
 
+        // Shared variants: the handle keeps its Step alive across
+        // build(), but after a rebuild it is disconnected from the new
+        // graph -- set()/get() touch only the old, unscheduled Step.
+        // nullptr when the name is absent.
+        template<typename T> std::shared_ptr<step::Input<T>>  input_shared (std::string_view name) const;
+        template<typename T> std::shared_ptr<step::Output<T>> output_shared(std::string_view name) const;
+
         // Pointer invalidated by build(). Returns nullptr for unknown ids.
         Step*       step_for(piper::NodeId id);
         Step const* step_for(piper::NodeId id) const;
+
+        // Shared variant: outlives build() but is disconnected from
+        // the new graph after a rebuild. nullptr for unknown ids.
+        std::shared_ptr<Step> step_shared(piper::NodeId id) const;
 
         // Views into engine-owned storage; invalidated by build().
         std::vector<Stage> const& stages() const;
@@ -75,26 +95,30 @@ namespace piper::engine
         std::vector<std::string>                                      stage_names_;   // owns the strings
         std::vector<Stage>                                            stage_data_;    // {string_view into stage_names_, hash}
         std::vector<std::vector<piper::NodeId>>                       per_stage_order_;
-        std::unordered_map<std::string, step::Input<float>*>          input_float_;
-        std::unordered_map<std::string, step::Input<double>*>         input_double_;
-        std::unordered_map<std::string, step::Input<int32_t>*>        input_int_;
-        std::unordered_map<std::string, step::Output<float>*>         output_float_;
-        std::unordered_map<std::string, step::Output<double>*>        output_double_;
-        std::unordered_map<std::string, step::Output<int32_t>*>       output_int_;
+        // per_stage_order_ resolved to IoBlock pointers at the end of
+        // build(); valid because unordered_map nodes are address-stable.
+        std::vector<std::vector<IoBlock*>>                            per_stage_blocks_;
+        // Aliasing shared_ptrs onto each block's shared_ptr<Step>, so
+        // a handle handed out via *_shared keeps its Step alive.
+        std::unordered_map<std::string, std::shared_ptr<step::Input<float>>>    input_float_;
+        std::unordered_map<std::string, std::shared_ptr<step::Input<double>>>   input_double_;
+        std::unordered_map<std::string, std::shared_ptr<step::Input<int32_t>>>  input_int_;
+        std::unordered_map<std::string, std::shared_ptr<step::Output<float>>>   output_float_;
+        std::unordered_map<std::string, std::shared_ptr<step::Output<double>>>  output_double_;
+        std::unordered_map<std::string, std::shared_ptr<step::Output<int32_t>>> output_int_;
         // Mode-aware execution. current_mode_name_ owns the active
         // profile name; current_mode_ is the {string_view, hash}
         // handle whose .name views into current_mode_name_. Every
         // IoBlock::current_mode points at &current_mode_ -- stable
         // across set_mode() calls. mode_labels_ caches each profile's
         // per_node table (cheaper than reaching back into the source
-        // Graph). active_disabled_ is the subset of nodes whose label
-        // in the active profile is "disable" -- consulted by tick_at
-        // on the hot path.
+        // Graph). Nodes labeled "disable" in the active profile carry
+        // IoBlock::disabled = true -- consulted by tick_at on the hot
+        // path.
         std::string                                                   current_mode_name_;
         Mode                                                          current_mode_{};
         std::unordered_map<std::string,
             std::unordered_map<piper::NodeId, std::string>>           mode_labels_;
-        std::unordered_set<piper::NodeId>                             active_disabled_;
         bool                                                          ok_{false};
 
         // Internal direct-dispatch tick. Bypasses the hash compare
@@ -108,6 +132,13 @@ namespace piper::engine
     template<> step::Output<float> const*   Engine::output<float> (std::string_view name) const;
     template<> step::Output<double> const*  Engine::output<double>(std::string_view name) const;
     template<> step::Output<int32_t> const* Engine::output<int32_t>(std::string_view name) const;
+
+    template<> std::shared_ptr<step::Input<float>>    Engine::input_shared<float>   (std::string_view name) const;
+    template<> std::shared_ptr<step::Input<double>>   Engine::input_shared<double>  (std::string_view name) const;
+    template<> std::shared_ptr<step::Input<int32_t>>  Engine::input_shared<int32_t> (std::string_view name) const;
+    template<> std::shared_ptr<step::Output<float>>   Engine::output_shared<float>  (std::string_view name) const;
+    template<> std::shared_ptr<step::Output<double>>  Engine::output_shared<double> (std::string_view name) const;
+    template<> std::shared_ptr<step::Output<int32_t>> Engine::output_shared<int32_t>(std::string_view name) const;
 }
 
 #endif

--- a/engine/include/piper/engine/external_io.h
+++ b/engine/include/piper/engine/external_io.h
@@ -20,6 +20,9 @@ namespace piper::engine::step
         void declare_io() override { declare_output<T>("out", out_); }
         void compute(Stage) override {}
 
+        ExternalIoKind   external_io_kind() const override { return ExternalIoKind::Input; }
+        std::string_view external_io_type() const override { return type_suffix<T>(); }
+
         void     set(T const& value) { out_ = value; }
         T const& get() const         { return out_; }
 
@@ -38,6 +41,9 @@ namespace piper::engine::step
 
         void declare_io() override { declare_input<T>("in"); }
         void compute(Stage) override { last_ = input<T>("in"); }
+
+        ExternalIoKind   external_io_kind() const override { return ExternalIoKind::Output; }
+        std::string_view external_io_type() const override { return type_suffix<T>(); }
 
         T const& get() const { return last_; }
 

--- a/engine/include/piper/engine/step.h
+++ b/engine/include/piper/engine/step.h
@@ -82,6 +82,10 @@ namespace piper::engine
         }
     }
 
+    // Optional inputs may stay unwired; Required ones fail build()
+    // with a MissingInput diagnostic when no link feeds them.
+    enum class InputPolicy { Required, Optional };
+
     // The matcher returns true iff the producer's `ref_any` was
     // published with the same T this declaration expects. It is a
     // function pointer (one per T), instantiated by declare_input<T>.
@@ -90,6 +94,7 @@ namespace piper::engine
     struct InputSlot
     {
         bool (*matches)(std::any const&){nullptr};
+        bool optional{false};
     };
 
     // Per-step runtime block. Step::io points at this; Engine owns it.
@@ -113,6 +118,9 @@ namespace piper::engine
         // points into label_buf below.
         std::string                                   label_buf;
         Mode                                          current_label{};
+        // True when the active profile labels this node "disable".
+        // Engine::set_mode keeps it in sync; tick_at reads it.
+        bool                                          disabled{false};
     };
 
     class Step
@@ -124,14 +132,22 @@ namespace piper::engine
 
         // io is null until just before declare_io() is invoked by
         // Engine::build(); calling input/output/member from a Step's
-        // constructor crashes.
+        // constructor throws std::logic_error.
         virtual void declare_io() {}
+
+        // Engine::build uses these to validate that a node registered
+        // under an external_input<T> / external_output<T> type string
+        // really is the engine's typed step before downcasting it.
+        enum class ExternalIoKind { None, Input, Output };
+        virtual ExternalIoKind   external_io_kind() const;
+        virtual std::string_view external_io_type() const;  // type_tag suffix, e.g. "<float>"
 
         // Read a wired input. Throws if the input was not wired by a
         // link or if T does not match the producer's published type.
         template<typename T>
         T const& input(std::string_view name) const
         {
+            require_io();
             auto it = io_->inputs.find(std::string(name));
             if (it == io_->inputs.end())
             {
@@ -145,6 +161,7 @@ namespace piper::engine
         // (e.g. dt on sin_wave / low_pass / pid).
         bool has_input(std::string_view name) const
         {
+            require_io();
             return io_->inputs.count(std::string(name)) != 0;
         }
 
@@ -187,14 +204,19 @@ namespace piper::engine
         // published type at link wire time via std::any_cast on the
         // producer's ref_any.
         template<typename T>
-        void declare_input(std::string_view name)
+        void declare_input(std::string_view name, InputPolicy policy = InputPolicy::Required)
         {
-            io_->input_slots[std::string(name)] = InputSlot{
-                [](std::any const& a)
-                {
-                    return std::any_cast<std::reference_wrapper<T const>>(&a) != nullptr;
-                }
+            require_io();
+            InputSlot slot;
+            slot.matches = [](std::any const& a)
+            {
+                return std::any_cast<std::reference_wrapper<T const>>(&a) != nullptr;
             };
+            if (policy == InputPolicy::Optional)
+            {
+                slot.optional = true;
+            }
+            io_->input_slots[std::string(name)] = slot;
         }
 
         // Inside declare_io(): declare a typed output backed by a
@@ -203,6 +225,7 @@ namespace piper::engine
         template<typename T>
         void declare_output(std::string_view name, T& slot)
         {
+            require_io();
             OutputSlot s;
             s.data    = static_cast<void*>(&slot);
             s.ref_any = std::any{ std::cref(slot) };
@@ -217,6 +240,7 @@ namespace piper::engine
         template<typename T>
         void declare_output(std::string_view name)
         {
+            require_io();
             auto& slot = managed_outputs_[std::string(name)];
             slot.template emplace<T>();
             declare_output<T>(name, std::any_cast<T&>(slot));
@@ -249,6 +273,9 @@ namespace piper::engine
 
         OutputSlot&       output_slot(std::string_view name);
         OutputSlot const& output_slot(std::string_view name) const;
+
+        // Throws std::logic_error when io_ is null.
+        void require_io() const;
     };
 }
 

--- a/engine/src/builtin_steps.cc
+++ b/engine/src/builtin_steps.cc
@@ -18,6 +18,7 @@
 #include "step/mux3.h"
 #include "step/pid.h"
 #include "step/preset3.h"
+#include "step/probe.h"
 #include "step/random.h"
 #include "step/sin_wave.h"
 #include "step/subtract.h"
@@ -70,6 +71,8 @@ namespace piper::engine
         register_step<step::Preset3<float>>   (sr);
         register_step<step::Preset3<double>>  (sr);
         register_step<step::Preset3<int32_t>> (sr);
+        register_step<step::Probe<float>>   (sr);
+        register_step<step::Probe<int32_t>> (sr);
         register_step<step::Random>         (sr);
         register_step<step::Cast<float, int32_t>>(sr);
         register_step<step::Cast<int32_t, float>>(sr);

--- a/engine/src/engine.cc
+++ b/engine/src/engine.cc
@@ -3,6 +3,7 @@
 #include <deque>
 #include <exception>
 #include <map>
+#include <memory>
 #include <set>
 #include <unordered_set>
 #include <utility>
@@ -41,6 +42,7 @@ namespace piper::engine
         stage_names_.clear();
         stage_data_.clear();
         per_stage_order_.clear();
+        per_stage_blocks_.clear();
         input_float_.clear();
         input_double_.clear();
         input_int_.clear();
@@ -50,7 +52,6 @@ namespace piper::engine
         current_mode_name_.clear();
         current_mode_ = Mode{};
         mode_labels_.clear();
-        active_disabled_.clear();
         ok_ = false;
 
         // ---- Snapshot stages ----
@@ -96,7 +97,20 @@ namespace piper::engine
                 continue;
             }
 
-            auto step_ptr = (*factory)();
+            std::shared_ptr<Step> step_ptr;
+            try
+            {
+                step_ptr = (*factory)();
+            }
+            catch (std::exception const& e)
+            {
+                result.diagnostics.push_back(
+                    make_build_diagnostic(BuildDiagnostic::Kind::StepConstructionFailed,
+                              "factory for type '" + node.type + "' threw: " + e.what(),
+                              node.id));
+                has_error = true;
+                continue;
+            }
             if (not step_ptr)
             {
                 result.diagnostics.push_back(
@@ -186,19 +200,48 @@ namespace piper::engine
                 continue;
             }
 
+            if (dst_block.inputs.count(link.to.attr) != 0)
+            {
+                result.diagnostics.push_back(
+                    make_build_diagnostic(BuildDiagnostic::Kind::DuplicateInputWiring,
+                              "input '" + link.to.attr + "' already has a wired producer",
+                              link.to.node, link.to.attr, link.id));
+                has_error = true;
+                continue;
+            }
+
             dst_block.inputs[link.to.attr] = out_it->second.ref_any;
+        }
+
+        // ---- Verify Required inputs are wired ----
+        for (auto const& node : graph.nodes())
+        {
+            auto block_it = blocks_.find(node.id);
+            if (block_it == blocks_.end())
+            {
+                continue;
+            }
+            auto const& block = block_it->second;
+            for (auto const& [pin, slot] : block.input_slots)
+            {
+                if (slot.optional or block.inputs.count(pin) != 0)
+                {
+                    continue;
+                }
+                result.diagnostics.push_back(
+                    make_build_diagnostic(BuildDiagnostic::Kind::MissingInput,
+                              "required input '" + pin + "' has no wired producer",
+                              node.id, pin));
+                has_error = true;
+            }
         }
 
         // ---- Index external_input / external_output nodes by name ----
         for (auto const& node : graph.nodes())
         {
-            bool const is_ext = node.type == "external_input<float>"
-                             or node.type == "external_input<double>"
-                             or node.type == "external_input<int32_t>"
-                             or node.type == "external_output<float>"
-                             or node.type == "external_output<double>"
-                             or node.type == "external_output<int32_t>";
-            if (not is_ext)
+            bool const is_input  = node.type.rfind("external_input<", 0) == 0;
+            bool const is_output = node.type.rfind("external_output<", 0) == 0;
+            if (not is_input and not is_output)
             {
                 continue;
             }
@@ -223,77 +266,83 @@ namespace piper::engine
                 continue;
             }
 
-            Step* step = block_it->second.step.get();
+            // Guard the static downcasts: a foreign step registered
+            // under one of these type strings would otherwise be cast
+            // to an unrelated type.
+            std::shared_ptr<Step> const& step = block_it->second.step;
+            Step::ExternalIoKind expected_kind = Step::ExternalIoKind::Output;
+            if (is_input)
+            {
+                expected_kind = Step::ExternalIoKind::Input;
+            }
+            std::string const expected_type = node.type.substr(node.type.find('<'));
+            if (step->external_io_kind() != expected_kind
+                or step->external_io_type() != expected_type)
+            {
+                result.diagnostics.push_back(
+                    make_build_diagnostic(BuildDiagnostic::Kind::FactoryTypeMismatch,
+                              "step registered as '" + node.type
+                                  + "' is not the engine's external IO step",
+                              node.id));
+                has_error = true;
+                continue;
+            }
+
+            auto emit_duplicate = [&]
+            {
+                result.diagnostics.push_back(
+                    make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
+                              "duplicate " + node.type + " name '" + name + "'",
+                              node.id, "name"));
+                has_error = true;
+            };
+
             if (node.type == "external_input<float>")
             {
-                auto* typed = static_cast<step::Input<float>*>(step);
-                if (not input_float_.emplace(name, typed).second)
+                auto typed = std::static_pointer_cast<step::Input<float>>(step);
+                if (not input_float_.emplace(name, std::move(typed)).second)
                 {
-                    result.diagnostics.push_back(
-                        make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
-                                  "duplicate external_input<float> name '" + name + "'",
-                                  node.id, "name"));
-                    has_error = true;
+                    emit_duplicate();
                 }
             }
             else if (node.type == "external_input<double>")
             {
-                auto* typed = static_cast<step::Input<double>*>(step);
-                if (not input_double_.emplace(name, typed).second)
+                auto typed = std::static_pointer_cast<step::Input<double>>(step);
+                if (not input_double_.emplace(name, std::move(typed)).second)
                 {
-                    result.diagnostics.push_back(
-                        make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
-                                  "duplicate external_input<double> name '" + name + "'",
-                                  node.id, "name"));
-                    has_error = true;
+                    emit_duplicate();
                 }
             }
             else if (node.type == "external_input<int32_t>")
             {
-                auto* typed = static_cast<step::Input<int32_t>*>(step);
-                if (not input_int_.emplace(name, typed).second)
+                auto typed = std::static_pointer_cast<step::Input<int32_t>>(step);
+                if (not input_int_.emplace(name, std::move(typed)).second)
                 {
-                    result.diagnostics.push_back(
-                        make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
-                                  "duplicate external_input<int32_t> name '" + name + "'",
-                                  node.id, "name"));
-                    has_error = true;
+                    emit_duplicate();
                 }
             }
             else if (node.type == "external_output<float>")
             {
-                auto* typed = static_cast<step::Output<float>*>(step);
-                if (not output_float_.emplace(name, typed).second)
+                auto typed = std::static_pointer_cast<step::Output<float>>(step);
+                if (not output_float_.emplace(name, std::move(typed)).second)
                 {
-                    result.diagnostics.push_back(
-                        make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
-                                  "duplicate external_output<float> name '" + name + "'",
-                                  node.id, "name"));
-                    has_error = true;
+                    emit_duplicate();
                 }
             }
             else if (node.type == "external_output<double>")
             {
-                auto* typed = static_cast<step::Output<double>*>(step);
-                if (not output_double_.emplace(name, typed).second)
+                auto typed = std::static_pointer_cast<step::Output<double>>(step);
+                if (not output_double_.emplace(name, std::move(typed)).second)
                 {
-                    result.diagnostics.push_back(
-                        make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
-                                  "duplicate external_output<double> name '" + name + "'",
-                                  node.id, "name"));
-                    has_error = true;
+                    emit_duplicate();
                 }
             }
             else
             {
-                auto* typed = static_cast<step::Output<int32_t>*>(step);
-                if (not output_int_.emplace(name, typed).second)
+                auto typed = std::static_pointer_cast<step::Output<int32_t>>(step);
+                if (not output_int_.emplace(name, std::move(typed)).second)
                 {
-                    result.diagnostics.push_back(
-                        make_build_diagnostic(BuildDiagnostic::Kind::UnresolvedInput,
-                                  "duplicate external_output<int32_t> name '" + name + "'",
-                                  node.id, "name"));
-                    has_error = true;
+                    emit_duplicate();
                 }
             }
         }
@@ -475,6 +524,24 @@ namespace piper::engine
             set_mode(graph.default_mode_name());
         }
 
+        // ---- Resolve per-stage tick order to block pointers ----
+        // blocks_ is not mutated after this point; unordered_map nodes
+        // are address-stable, so the pointers survive set_mode().
+        per_stage_blocks_.resize(per_stage_order_.size());
+        for (std::size_t s = 0; s < per_stage_order_.size(); ++s)
+        {
+            auto& resolved = per_stage_blocks_[s];
+            resolved.reserve(per_stage_order_[s].size());
+            for (auto id : per_stage_order_[s])
+            {
+                auto bit = blocks_.find(id);
+                if (bit != blocks_.end())
+                {
+                    resolved.push_back(&bit->second);
+                }
+            }
+        }
+
         ok_ = not has_error;
         result.ok = ok_;
         return result;
@@ -484,11 +551,11 @@ namespace piper::engine
     {
         current_mode_name_.assign(name.begin(), name.end());
         current_mode_ = Mode{current_mode_name_};
-        active_disabled_.clear();
         for (auto& [_, block] : blocks_)
         {
             block.label_buf.clear();
             block.current_label = Mode{};
+            block.disabled      = false;
         }
 
         auto it = mode_labels_.find(current_mode_name_);
@@ -503,10 +570,10 @@ namespace piper::engine
             {
                 bit->second.label_buf     = label;
                 bit->second.current_label = Mode{bit->second.label_buf};
-            }
-            if (label == "disable")
-            {
-                active_disabled_.insert(id);
+                if (label == "disable")
+                {
+                    bit->second.disabled = true;
+                }
             }
         }
     }
@@ -514,19 +581,13 @@ namespace piper::engine
     void Engine::tick_at(std::size_t idx)
     {
         Stage const& stage = stage_data_[idx];
-        auto const&  order = per_stage_order_[idx];
-        for (auto id : order)
+        for (auto* block : per_stage_blocks_[idx])
         {
-            if (active_disabled_.count(id) != 0)
+            if (block->disabled)
             {
                 continue;
             }
-            auto bit = blocks_.find(id);
-            if (bit == blocks_.end())
-            {
-                continue;
-            }
-            bit->second.step->compute(stage);
+            block->step->compute(stage);
         }
     }
 
@@ -581,6 +642,16 @@ namespace piper::engine
         return it->second.step.get();
     }
 
+    std::shared_ptr<Step> Engine::step_shared(piper::NodeId id) const
+    {
+        auto it = blocks_.find(id);
+        if (it == blocks_.end())
+        {
+            return nullptr;
+        }
+        return it->second.step;
+    }
+
     std::vector<Stage> const& Engine::stages() const
     {
         return stage_data_;
@@ -594,7 +665,7 @@ namespace piper::engine
         {
             return nullptr;
         }
-        return it->second;
+        return it->second.get();
     }
 
     template<>
@@ -605,7 +676,7 @@ namespace piper::engine
         {
             return nullptr;
         }
-        return it->second;
+        return it->second.get();
     }
 
     template<>
@@ -616,7 +687,7 @@ namespace piper::engine
         {
             return nullptr;
         }
-        return it->second;
+        return it->second.get();
     }
 
     template<>
@@ -627,7 +698,7 @@ namespace piper::engine
         {
             return nullptr;
         }
-        return it->second;
+        return it->second.get();
     }
 
     template<>
@@ -638,11 +709,77 @@ namespace piper::engine
         {
             return nullptr;
         }
-        return it->second;
+        return it->second.get();
     }
 
     template<>
     step::Output<int32_t> const* Engine::output<int32_t>(std::string_view name) const
+    {
+        auto it = output_int_.find(std::string(name));
+        if (it == output_int_.end())
+        {
+            return nullptr;
+        }
+        return it->second.get();
+    }
+
+    template<>
+    std::shared_ptr<step::Input<float>> Engine::input_shared<float>(std::string_view name) const
+    {
+        auto it = input_float_.find(std::string(name));
+        if (it == input_float_.end())
+        {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    template<>
+    std::shared_ptr<step::Input<double>> Engine::input_shared<double>(std::string_view name) const
+    {
+        auto it = input_double_.find(std::string(name));
+        if (it == input_double_.end())
+        {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    template<>
+    std::shared_ptr<step::Input<int32_t>> Engine::input_shared<int32_t>(std::string_view name) const
+    {
+        auto it = input_int_.find(std::string(name));
+        if (it == input_int_.end())
+        {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    template<>
+    std::shared_ptr<step::Output<float>> Engine::output_shared<float>(std::string_view name) const
+    {
+        auto it = output_float_.find(std::string(name));
+        if (it == output_float_.end())
+        {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    template<>
+    std::shared_ptr<step::Output<double>> Engine::output_shared<double>(std::string_view name) const
+    {
+        auto it = output_double_.find(std::string(name));
+        if (it == output_double_.end())
+        {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    template<>
+    std::shared_ptr<step::Output<int32_t>> Engine::output_shared<int32_t>(std::string_view name) const
     {
         auto it = output_int_.find(std::string(name));
         if (it == output_int_.end())

--- a/engine/src/step.cc
+++ b/engine/src/step.cc
@@ -7,8 +7,27 @@ namespace piper::engine
 {
     Step::~Step() = default;
 
+    Step::ExternalIoKind Step::external_io_kind() const
+    {
+        return ExternalIoKind::None;
+    }
+
+    std::string_view Step::external_io_type() const
+    {
+        return {};
+    }
+
+    void Step::require_io() const
+    {
+        if (io_ == nullptr)
+        {
+            throw std::logic_error("Step I/O not initialized; only valid inside declare_io()/compute()");
+        }
+    }
+
     std::string const& Step::member(std::string_view name) const
     {
+        require_io();
         auto it = io_->members.find(std::string(name));
         if (it == io_->members.end())
         {
@@ -19,6 +38,7 @@ namespace piper::engine
 
     Mode Step::current_mode() const
     {
+        require_io();
         if (io_->current_mode == nullptr)
         {
             return {};
@@ -28,11 +48,13 @@ namespace piper::engine
 
     Mode Step::current_label() const
     {
+        require_io();
         return io_->current_label;
     }
 
     OutputSlot& Step::output_slot(std::string_view name)
     {
+        require_io();
         auto it = io_->output_slots.find(std::string(name));
         if (it == io_->output_slots.end())
         {
@@ -43,6 +65,7 @@ namespace piper::engine
 
     OutputSlot const& Step::output_slot(std::string_view name) const
     {
+        require_io();
         auto it = io_->output_slots.find(std::string(name));
         if (it == io_->output_slots.end())
         {

--- a/engine/src/step/low_pass.h
+++ b/engine/src/step/low_pass.h
@@ -17,7 +17,7 @@ namespace piper::engine::step
         void declare_io() override
         {
             declare_input<T>("in");
-            declare_input<T>("dt_in");
+            declare_input<T>("dt_in", InputPolicy::Optional);
             declare_output<T>("out", out_);
             cutoff_    = std::stod(member("cutoff"));
             dt_member_ = std::stod(member("dt"));

--- a/engine/src/step/pid.h
+++ b/engine/src/step/pid.h
@@ -18,11 +18,9 @@ namespace piper::engine::step
     //    measurement instead leaves the derivative term as just
     //    "resist the plant's velocity" with no setpoint-step kick.
     //
-    // 2) Derivative passes through a 1-pole low-pass at fc=16 Hz.
-    //    At 1 kHz sampling, an unfiltered (m - m_prev)/dt amplifies
-    //    every per-tick wiggle by 1000; the filter caps that gain so
-    //    a small kd stays small. Tau is hardcoded; promote to a
-    //    member if a demo needs to tune it.
+    // 2) Derivative passes through a 1-pole low-pass with a fixed
+    //    smoothing factor of 1/11 per tick (tau = 10*dt), so the
+    //    cutoff frequency scales with the sample rate.
     //
     // 3) Anti-windup via output saturation + conditional integration.
     //    out is clamped to [out_min, out_max] (members; default
@@ -47,7 +45,7 @@ namespace piper::engine::step
             declare_input<T>("kp");
             declare_input<T>("ki");
             declare_input<T>("kd");
-            declare_input<T>("dt_in");
+            declare_input<T>("dt_in", InputPolicy::Optional);
             declare_output<T>("out", out_);
             dt_member_  = std::stod(member("dt"));
             out_min_    = std::stod(member("out_min"));

--- a/engine/src/step/probe.h
+++ b/engine/src/step/probe.h
@@ -1,0 +1,38 @@
+#ifndef PIPER_ENGINE_STEPS_PROBE_STEP_H
+#define PIPER_ENGINE_STEPS_PROBE_STEP_H
+
+#include <string>
+
+#include "piper/engine/step.h"
+
+namespace piper::engine::step
+{
+    // Inspection sink: latches the wired value each tick so the host
+    // can read it via last(). Unwired probes tick as a no-op.
+    template<typename T>
+    class Probe final : public Step
+    {
+    public:
+        static std::string type_name() { return std::string("probe") + type_suffix<T>(); }
+
+        void declare_io() override
+        {
+            declare_input<T>("in", InputPolicy::Optional);
+        }
+
+        void compute(Stage) override
+        {
+            if (has_input("in"))
+            {
+                last_ = input<T>("in");
+            }
+        }
+
+        T const& last() const { return last_; }
+
+    private:
+        T last_{};
+    };
+}
+
+#endif

--- a/engine/src/step/sin_wave.h
+++ b/engine/src/step/sin_wave.h
@@ -21,7 +21,7 @@ namespace piper::engine::step
 
         void declare_io() override
         {
-            declare_input<T>("dt_in");
+            declare_input<T>("dt_in", InputPolicy::Optional);
             declare_output<T>("out", out_);
             frequency_ = std::stod(member("frequency"));
             amplitude_ = std::stod(member("amplitude"));

--- a/migrate/CMakeLists.txt
+++ b/migrate/CMakeLists.txt
@@ -22,3 +22,5 @@ target_link_libraries(piper_migrate_cli PRIVATE
     argparse::argparse
 )
 set_target_properties(piper_migrate_cli PROPERTIES OUTPUT_NAME piper-migrate)
+
+install(TARGETS piper_migrate_cli RUNTIME DESTINATION bin)

--- a/migrate/include/piper/migrate/v1_reader.h
+++ b/migrate/include/piper/migrate/v1_reader.h
@@ -10,18 +10,14 @@ namespace piper::migrate
 {
     struct Options
     {
-        // --strict upgrades reader warnings (orphan links, unknown
-        // mode labels, ...) into hard errors. Currently honored as a
-        // no-op.
-        bool strict = false;
     };
 
     // Reads a V1-era pipeline JSON document and produces a bundle of
     // V2 pipelines (one per top-level key in the V1 document). Returns
     // structural drift (orphan links, unknown attributes, ...) through
     // the per-pipeline diagnostics. Throws std::runtime_error only on
-    // malformed JSON or schema-level violations the reader cannot
-    // recover from.
+    // malformed JSON, input that is already a v2/v3 document, or
+    // schema-level violations the reader cannot recover from.
     v2::BundleLoadResult read_v1(std::string_view             json,
                                   NodeRegistry const&          registry,
                                   Options const&               opts = {});

--- a/migrate/main.cc
+++ b/migrate/main.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 #include <argparse/argparse.hpp>
 
@@ -37,6 +38,15 @@ namespace
             throw std::runtime_error("cannot write: " + path.string());
         }
         out.write(data.data(), static_cast<std::streamsize>(data.size()));
+        if (not out)
+        {
+            throw std::runtime_error("write failed: " + path.string());
+        }
+        out.close();
+        if (out.fail())
+        {
+            throw std::runtime_error("write failed (close): " + path.string());
+        }
     }
 
     fs::path default_output(fs::path const& input)
@@ -118,16 +128,36 @@ int main(int argc, char* argv[])
     bool const dry_run = cli.get<bool>("--dry-run");
     bool const strict  = cli.get<bool>("--strict");
 
+    {
+        std::error_code   ec_in;
+        std::error_code   ec_out;
+        fs::path          in_resolved  = fs::weakly_canonical(input, ec_in);
+        fs::path          out_resolved = fs::weakly_canonical(output, ec_out);
+        if (ec_in)
+        {
+            in_resolved = fs::absolute(input).lexically_normal();
+        }
+        if (ec_out)
+        {
+            out_resolved = fs::absolute(output).lexically_normal();
+        }
+        if (in_resolved == out_resolved)
+        {
+            std::fprintf(stderr,
+                         "piper-migrate: output path '%s' is the input file; "
+                         "refusing to overwrite it (use -o to pick another path)\n",
+                         output.string().c_str());
+            return 1;
+        }
+    }
+
     piper::NodeRegistry registry;
     piper::register_builtin_nodes(registry);
-
-    piper::migrate::Options opts;
-    opts.strict = strict;
 
     try
     {
         std::string const v1_json = read_file(input);
-        auto              bundle  = piper::migrate::read_v1(v1_json, registry, opts);
+        auto              bundle  = piper::migrate::read_v1(v1_json, registry);
 
         std::size_t total_diags     = bundle.diagnostics.size();
         std::size_t critical_diags  = 0;
@@ -168,6 +198,12 @@ int main(int argc, char* argv[])
             std::fprintf(stderr,
                          "piper-migrate: %zu critical diagnostic(s) -- aborting (no output written)\n",
                          critical_diags);
+            return 1;
+        }
+        if (bundle.pipelines.empty())
+        {
+            std::fprintf(stderr,
+                         "piper-migrate: conversion produced no pipelines -- aborting (no output written)\n");
             return 1;
         }
         if (strict and total_diags > 0)

--- a/migrate/src/v1_reader.cc
+++ b/migrate/src/v1_reader.cc
@@ -95,8 +95,21 @@ namespace piper::migrate
                 out.diagnostics.push_back(d);
                 continue;
             }
-            std::string const type  = node_json.value("type",  std::string{});
-            std::string const stage = node_json.value("stage", std::string{});
+            std::string type;
+            std::string stage;
+            try
+            {
+                type  = node_json.value("type",  std::string{});
+                stage = node_json.value("stage", std::string{});
+            }
+            catch (json::exception const& e)
+            {
+                Diagnostic d;
+                d.kind    = Diagnostic::Kind::SchemaError;
+                d.message = "node '" + v1_name + "' has malformed field: " + e.what();
+                out.diagnostics.push_back(d);
+                continue;
+            }
 
             if (type.empty())
             {
@@ -171,11 +184,27 @@ namespace piper::migrate
                     invalid_node_id, std::string{}, invalid_link_id });
                 continue;
             }
-            std::string const from_name = link_json.value("from", std::string{});
-            std::string const out_attr  = link_json.value("out",  std::string{});
-            std::string const to_name   = link_json.value("to",   std::string{});
-            std::string const in_attr   = link_json.value("in",   std::string{});
-            std::string const data_type = link_json.value("type", std::string{});
+            std::string from_name;
+            std::string out_attr;
+            std::string to_name;
+            std::string in_attr;
+            std::string data_type;
+            try
+            {
+                from_name = link_json.value("from", std::string{});
+                out_attr  = link_json.value("out",  std::string{});
+                to_name   = link_json.value("to",   std::string{});
+                in_attr   = link_json.value("in",   std::string{});
+                data_type = link_json.value("type", std::string{});
+            }
+            catch (json::exception const& e)
+            {
+                Diagnostic d;
+                d.kind    = Diagnostic::Kind::SchemaError;
+                d.message = std::string("link entry has malformed field: ") + e.what();
+                out.diagnostics.push_back(d);
+                continue;
+            }
 
             auto const it_from = name_to_id.find(from_name);
             auto const it_to   = name_to_id.find(to_name);
@@ -235,38 +264,48 @@ namespace piper::migrate
                 continue;
             }
 
-            ModeProfile profile;
-            profile.name = key;
-
-            auto config_it = value.find("configuration");
-            if (config_it != value.end() and config_it->is_object())
+            try
             {
-                for (auto const& [node_name, label_json] : config_it->items())
+                ModeProfile profile;
+                profile.name = key;
+
+                auto config_it = value.find("configuration");
+                if (config_it != value.end() and config_it->is_object())
                 {
-                    if (not label_json.is_string())
+                    for (auto const& [node_name, label_json] : config_it->items())
                     {
-                        continue;
+                        if (not label_json.is_string())
+                        {
+                            continue;
+                        }
+                        auto name_it = name_to_id.find(node_name);
+                        if (name_it == name_to_id.end())
+                        {
+                            Diagnostic d;
+                            d.kind    = Diagnostic::Kind::OrphanModeReference;
+                            d.message = "mode profile '" + key + "' references unknown node '"
+                                      + node_name + "'";
+                            out.diagnostics.push_back(d);
+                            continue;
+                        }
+                        profile.per_node[name_it->second] =
+                            normalize_mode_label(label_json.get<std::string>());
                     }
-                    auto name_it = name_to_id.find(node_name);
-                    if (name_it == name_to_id.end())
-                    {
-                        Diagnostic d;
-                        d.kind    = Diagnostic::Kind::OrphanModeReference;
-                        d.message = "mode profile '" + key + "' references unknown node '"
-                                  + node_name + "'";
-                        out.diagnostics.push_back(d);
-                        continue;
-                    }
-                    profile.per_node[name_it->second] =
-                        normalize_mode_label(label_json.get<std::string>());
+                }
+
+                if (not out.graph.add_mode_profile(profile))
+                {
+                    Diagnostic d;
+                    d.kind    = Diagnostic::Kind::DuplicateProfileName;
+                    d.message = "duplicate mode profile name '" + profile.name + "'";
+                    out.diagnostics.push_back(d);
                 }
             }
-
-            if (not out.graph.add_mode_profile(profile))
+            catch (json::exception const& e)
             {
                 Diagnostic d;
-                d.kind    = Diagnostic::Kind::DuplicateProfileName;
-                d.message = "duplicate mode profile name '" + profile.name + "'";
+                d.kind    = Diagnostic::Kind::SchemaError;
+                d.message = "mode profile '" + key + "' has malformed field: " + e.what();
                 out.diagnostics.push_back(d);
             }
         }
@@ -303,10 +342,26 @@ namespace piper::migrate
         {
             throw std::runtime_error("V1 file: expected top-level object keyed by pipeline name");
         }
+        // V2/V3 files carry an integer top-level "version"; V1 keys
+        // every top-level entry by pipeline name.
+        auto const version_it = doc.find("version");
+        if (version_it != doc.end()
+            and version_it->is_number_integer()
+            and version_it->get<int>() >= 2)
+        {
+            throw std::runtime_error(
+                "input is already a v2/v3 piper file (version "
+                + std::to_string(version_it->get<int>())
+                + "); refusing to migrate it");
+        }
 
         v2::BundleLoadResult result;
         for (auto const& [pipeline_name, pipeline_json] : doc.items())
         {
+            if (pipeline_name == "version")
+            {
+                continue;
+            }
             if (not pipeline_json.is_object())
             {
                 Diagnostic d;

--- a/py_bindings/CMakeLists.txt
+++ b/py_bindings/CMakeLists.txt
@@ -7,6 +7,7 @@ execute_process(
     COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE nanobind_DIR
+    COMMAND_ERROR_IS_FATAL ANY
 )
 find_package(nanobind CONFIG REQUIRED)
 

--- a/py_bindings/src/engine_module.cc
+++ b/py_bindings/src/engine_module.cc
@@ -7,6 +7,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/function.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/vector.h>
@@ -54,7 +55,12 @@ void bind_engine(nb::module_ m)
         .value("CycleDetected",        eng::BuildDiagnostic::Kind::CycleDetected)
         .value("UnknownStageOnPin",    eng::BuildDiagnostic::Kind::UnknownStageOnPin)
         .value("NodeNeverScheduled",   eng::BuildDiagnostic::Kind::NodeNeverScheduled)
-        .value("StepDeclareIoFailed",  eng::BuildDiagnostic::Kind::StepDeclareIoFailed);
+        .value("StepDeclareIoFailed",  eng::BuildDiagnostic::Kind::StepDeclareIoFailed)
+        .value("MissingInput",         eng::BuildDiagnostic::Kind::MissingInput)
+        .value("DuplicateInputWiring", eng::BuildDiagnostic::Kind::DuplicateInputWiring)
+        .value("StepConstructionFailed",
+               eng::BuildDiagnostic::Kind::StepConstructionFailed)
+        .value("FactoryTypeMismatch",  eng::BuildDiagnostic::Kind::FactoryTypeMismatch);
     bd_class
         .def(nb::init<>())
         .def_rw("kind",      &eng::BuildDiagnostic::kind)
@@ -78,9 +84,11 @@ void bind_engine(nb::module_ m)
     // hash from piper.engine.hash_name("...").
     nb::class_<eng::Stage>(m, "Stage")
         .def(nb::init<>())
+        // Stage::name borrows the Python str's UTF-8 buffer; keep the
+        // str alive as long as the Stage instance.
         .def("__init__",
              [](eng::Stage* self, std::string_view name) { new (self) eng::Stage{name}; },
-             "name"_a)
+             "name"_a, nb::keep_alive<1, 2>())
         .def_prop_ro("name",
                      [](eng::Stage const& s) { return std::string{s.name}; })
         .def_ro("id", &eng::Stage::id)
@@ -187,35 +195,50 @@ void bind_engine(nb::module_ m)
                  self.play();
              })
         .def("input_float",
-             [](eng::Engine& self, std::string_view name) {
-                 return self.input<float>(name);
+             [](eng::Engine const& self, std::string_view name) {
+                 return self.input_shared<float>(name);
              },
-             nb::rv_policy::reference_internal,
-             "name"_a)
+             "name"_a,
+             "Resolve an external float input by name, or None. The "
+             "handle stays alive across build(), but a rebuild "
+             "disconnects it from the new graph -- re-resolve after "
+             "build().")
         .def("input_int",
-             [](eng::Engine& self, std::string_view name) {
-                 return self.input<int32_t>(name);
+             [](eng::Engine const& self, std::string_view name) {
+                 return self.input_shared<int32_t>(name);
              },
-             nb::rv_policy::reference_internal,
-             "name"_a)
+             "name"_a,
+             "Resolve an external int input by name, or None. The "
+             "handle stays alive across build(), but a rebuild "
+             "disconnects it from the new graph -- re-resolve after "
+             "build().")
         .def("output_float",
              [](eng::Engine const& self, std::string_view name) {
-                 return self.output<float>(name);
+                 return self.output_shared<float>(name);
              },
-             nb::rv_policy::reference_internal,
-             "name"_a)
+             "name"_a,
+             "Resolve an external float output by name, or None. The "
+             "handle stays alive across build(), but a rebuild "
+             "disconnects it from the new graph -- re-resolve after "
+             "build().")
         .def("output_int",
              [](eng::Engine const& self, std::string_view name) {
-                 return self.output<int32_t>(name);
+                 return self.output_shared<int32_t>(name);
              },
-             nb::rv_policy::reference_internal,
-             "name"_a)
+             "name"_a,
+             "Resolve an external int output by name, or None. The "
+             "handle stays alive across build(), but a rebuild "
+             "disconnects it from the new graph -- re-resolve after "
+             "build().")
         .def("step_for",
-             [](eng::Engine& self, piper::NodeId id) -> eng::Step* {
-                 return self.step_for(id);
+             [](eng::Engine const& self, piper::NodeId id) {
+                 return self.step_shared(id);
              },
-             nb::rv_policy::reference_internal,
-             "node_id"_a)
+             "node_id"_a,
+             "Resolve the Step built for a node id, or None. The "
+             "handle stays alive across build(), but a rebuild "
+             "disconnects it from the new graph -- re-resolve after "
+             "build().")
         .def("stages",
              [](eng::Engine const& self) {
                  std::vector<std::string> out;
@@ -237,26 +260,34 @@ void bind_engine(nb::module_ m)
     // reference (which destroys the C++ side).
     m.def("register_step_type_py",
           [](eng::StepRegistry& sr, std::string type_name, nb::object py_class) {
-              sr.add(std::move(type_name),
-                     [py_class]() -> std::shared_ptr<eng::Step> {
-                         nb::gil_scoped_acquire gil;
-                         nb::object instance = py_class();
-                         eng::Step* raw = nb::cast<eng::Step*>(instance);
-                         // Holder keeps the Python ref alive; its
-                         // deleter must acquire the GIL because the
-                         // engine drops shared_ptrs from C++ paths
-                         // that may not hold it.
-                         auto holder = std::shared_ptr<nb::object>(
-                             new nb::object(std::move(instance)),
-                             [](nb::object* p) {
-                                 nb::gil_scoped_acquire gil;
-                                 delete p;
-                             });
-                         return std::shared_ptr<eng::Step>(holder, raw);
-                     });
+              bool const added =
+                  sr.add(type_name,
+                         [py_class]() -> std::shared_ptr<eng::Step> {
+                             nb::gil_scoped_acquire gil;
+                             nb::object instance = py_class();
+                             eng::Step* raw = nb::cast<eng::Step*>(instance);
+                             // Holder keeps the Python ref alive; its
+                             // deleter must acquire the GIL because the
+                             // engine drops shared_ptrs from C++ paths
+                             // that may not hold it.
+                             auto holder = std::shared_ptr<nb::object>(
+                                 new nb::object(std::move(instance)),
+                                 [](nb::object* p) {
+                                     nb::gil_scoped_acquire gil;
+                                     delete p;
+                                 });
+                             return std::shared_ptr<eng::Step>(holder, raw);
+                         });
+              if (!added)
+              {
+                  std::string const msg =
+                      "step type already registered: '" + type_name + "'";
+                  throw nb::value_error(msg.c_str());
+              }
           },
           "step_registry"_a, "type_name"_a, "py_class"_a,
           "Register a Python Step subclass under the given type name. "
           "Each engine build that references this type instantiates a "
-          "fresh Python instance.");
+          "fresh Python instance. Raises ValueError if the type name "
+          "is already registered.");
 }

--- a/py_bindings/src/piper_module.cc
+++ b/py_bindings/src/piper_module.cc
@@ -48,7 +48,9 @@ NB_MODULE(piper, m)
         .value("LinkOrphanedAttribute",  Diagnostic::Kind::LinkOrphanedAttribute)
         .value("LinkTypeMismatch",       Diagnostic::Kind::LinkTypeMismatch)
         .value("OrphanModeReference",    Diagnostic::Kind::OrphanModeReference)
-        .value("UnknownStageReference",  Diagnostic::Kind::UnknownStageReference);
+        .value("UnknownStageReference",  Diagnostic::Kind::UnknownStageReference)
+        .value("LabelClusterRepaired",   Diagnostic::Kind::LabelClusterRepaired)
+        .value("Lint",                   Diagnostic::Kind::Lint);
     diag_class
         .def(nb::init<>())
         .def_rw("kind",      &Diagnostic::kind)
@@ -133,7 +135,8 @@ NB_MODULE(piper, m)
              {
                  return n.find_attr(name);
              },
-             nb::rv_policy::reference_internal);
+             nb::rv_policy::copy,
+             "Returns a snapshot copy of the attribute (or None); later mutations are not reflected.");
 
     // ---- Link ----
     nb::class_<Link>(m, "Link")
@@ -258,15 +261,17 @@ NB_MODULE(piper, m)
              {
                  return g.find_node(id);
              },
-             nb::rv_policy::reference_internal,
-             nb::arg("id"))
+             nb::rv_policy::copy,
+             nb::arg("id"),
+             "Returns a snapshot copy of the node (or None); mutate through Graph methods.")
         .def("find_link",
              [](Graph const& g, LinkId id) -> Link const*
              {
                  return g.find_link(id);
              },
-             nb::rv_policy::reference_internal,
-             nb::arg("id"));
+             nb::rv_policy::copy,
+             nb::arg("id"),
+             "Returns a snapshot copy of the link (or None); mutate through Graph methods.");
 
     // ---- piper.v2 submodule ----
     auto v2 = m.def_submodule("v2", "V2 file format serializer / deserializer.");

--- a/py_bindings/tests/test_bindings.py
+++ b/py_bindings/tests/test_bindings.py
@@ -64,6 +64,40 @@ class TestGraph(unittest.TestCase):
         self.assertIsNotNone(cutoff_attr)
         self.assertEqual(cutoff_attr.value, "5.0")
 
+    def test_find_node_returns_snapshot(self):
+        g = piper.Graph()
+        nt = self.reg.find("constant<float>")
+        node = g.add_node(nt, "orig", "", piper.Point(1, 2))
+        snap = g.find_node(node)
+        self.assertTrue(g.rename_node(node, "renamed"))
+        self.assertTrue(g.move_node(node, piper.Point(50, 60)))
+        # The snapshot is a copy; graph mutations do not show through.
+        self.assertEqual(snap.name, "orig")
+        self.assertEqual(snap.pos, piper.Point(1, 2))
+        fresh = g.find_node(node)
+        self.assertEqual(fresh.name, "renamed")
+        self.assertEqual(fresh.pos, piper.Point(50, 60))
+
+    def test_find_attr_returns_snapshot(self):
+        g = piper.Graph()
+        nt = self.reg.find("low_pass<float>")
+        node = g.add_node(nt, "f", "", piper.Point(0, 0))
+        self.assertTrue(g.set_attr_value(node, "cutoff", "1.0"))
+        attr = g.find_node(node).find_attr("cutoff")
+        self.assertTrue(g.set_attr_value(node, "cutoff", "9.0"))
+        self.assertEqual(attr.value, "1.0")
+        self.assertEqual(g.find_node(node).find_attr("cutoff").value, "9.0")
+
+    def test_find_node_snapshot_survives_vector_growth(self):
+        g = piper.Graph()
+        nt = self.reg.find("constant<float>")
+        first = g.add_node(nt, "first", "", piper.Point(0, 0))
+        snap = g.find_node(first)
+        for i in range(64):  # force node-vector reallocation
+            g.add_node(nt, "n%d" % i, "", piper.Point(0, 0))
+        self.assertEqual(snap.name, "first")
+        self.assertEqual(snap.id, first)
+
     def test_remove_node_cascades_to_links(self):
         g = piper.Graph()
         sin_t   = self.reg.find("sin_wave<float>")
@@ -157,12 +191,25 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_unknown_type_fires_diagnostic(self):
         g = piper.Graph()
-        text = piper.v2.serialize(g, "x")  # empty
+        nt = self.reg.find("constant<float>")
+        g.add_node(nt, "n", "", piper.Point(0, 0))
+        text = piper.v2.serialize(g, "x")
         empty_reg = piper.NodeRegistry()  # no builtins
         loaded = piper.v2.deserialize(text, empty_reg)
-        # An empty graph round-trips with zero diagnostics even against
-        # an empty registry.
-        self.assertEqual(len(loaded.diagnostics), 0)
+        kinds = {d.kind for d in loaded.diagnostics}
+        self.assertIn(piper.Diagnostic.Kind.UnknownNodeType, kinds)
+        # Loading still proceeds -- the node is preserved verbatim.
+        self.assertEqual(len(loaded.graph.nodes()), 1)
+        self.assertEqual(loaded.graph.nodes()[0].type, "constant<float>")
+
+
+class TestDiagnosticKind(unittest.TestCase):
+    def test_late_enumerators_are_bound(self):
+        d = piper.Diagnostic()
+        d.kind = piper.Diagnostic.Kind.LabelClusterRepaired
+        self.assertEqual(d.kind, piper.Diagnostic.Kind.LabelClusterRepaired)
+        d.kind = piper.Diagnostic.Kind.Lint
+        self.assertEqual(d.kind, piper.Diagnostic.Kind.Lint)
 
 
 class TestStagesAndModes(unittest.TestCase):

--- a/py_bindings/tests/test_engine.py
+++ b/py_bindings/tests/test_engine.py
@@ -232,6 +232,102 @@ class TestExternalIO(unittest.TestCase):
         self.assertIsNone(e.input_int("valid"))
 
 
+class TestBuildDiagnostics(unittest.TestCase):
+    def test_unwired_required_input_emits_missing_input(self):
+        nr = piper.NodeRegistry()
+        piper.register_builtin_nodes(nr)
+        g = piper.Graph()
+        g.add_stage(_make_stage("control"))
+        # external_output<float> has a required "in" pin; leave it unwired.
+        sink = g.add_node(nr.find("external_output<float>"),
+                          "sink", "control", piper.Point(0, 0))
+        g.set_attr_value(sink, "name", "measured")
+
+        sr = eng.StepRegistry()
+        eng.register_builtin_steps(sr)
+        e = eng.Engine()
+        result = e.build(g, sr)
+        self.assertFalse(result.ok)
+        kinds = {d.kind for d in result.diagnostics}
+        self.assertIn(eng.BuildDiagnostic.Kind.MissingInput, kinds)
+
+
+class TestHandleLifetime(unittest.TestCase):
+    def test_io_handles_survive_rebuild(self):
+        g, _ = _build_constant_to_probe(2.0)
+        in_id = g.add_node(_registry().find("external_input<float>"),
+                           "ipc_in", "control", piper.Point(0, 1))
+        g.set_attr_value(in_id, "name", "target")
+
+        sr = eng.StepRegistry()
+        eng.register_builtin_steps(sr)
+        e = eng.Engine()
+        self.assertTrue(e.build(g, sr).ok)
+
+        target = e.input_float("target")
+        self.assertIsNotNone(target)
+        target.set(0.25)
+
+        # Rebuild: the old handle stays alive but is disconnected from
+        # the new graph. Using it must not crash.
+        self.assertTrue(e.build(g, sr).ok)
+        target.set(0.5)
+        self.assertAlmostEqual(target.get(), 0.5, places=5)
+
+        fresh = e.input_float("target")
+        self.assertIsNotNone(fresh)
+
+    def test_step_handle_survives_rebuild(self):
+        g, probe_id = _build_constant_to_probe(1.0)
+        sr = eng.StepRegistry()
+        eng.register_builtin_steps(sr)
+        e = eng.Engine()
+        self.assertTrue(e.build(g, sr).ok)
+        e.tick("control")
+
+        probe = e.step_for(probe_id)
+        self.assertIsNotNone(probe)
+
+        # The old handle keeps the Step object alive across the rebuild.
+        self.assertTrue(e.build(g, sr).ok)
+        self.assertIsNotNone(probe)
+        fresh = e.step_for(probe_id)
+        self.assertIsNotNone(fresh)
+
+
+class TestStepMisuse(unittest.TestCase):
+    def test_accessor_before_init_raises(self):
+        class Bare(eng.Step):
+            def compute(self, _stage):
+                pass
+
+        s = Bare()
+        # Not built into an engine: accessors raise instead of crashing.
+        with self.assertRaises(RuntimeError):
+            s.read_input_float("in")
+        with self.assertRaises(RuntimeError):
+            s.declare_output_float("out")
+
+
+class TestRegistration(unittest.TestCase):
+    def test_duplicate_register_step_type_raises(self):
+        class S(eng.Step):
+            def compute(self, _stage):
+                pass
+
+        sr = eng.StepRegistry()
+        eng.register_step_type_py(sr, "py_dup", S)
+        with self.assertRaises(ValueError):
+            eng.register_step_type_py(sr, "py_dup", S)
+        self.assertEqual(sr.size(), 1)
+
+
+def _registry():
+    nr = piper.NodeRegistry()
+    piper.register_builtin_nodes(nr)
+    return nr
+
+
 def _attr(name, dtype, role, default=""):
     a = piper.AttributeSpec()
     a.name          = name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["scikit-build-core >=0.10", "nanobind >=2.0"]
+requires = ["scikit-build-core >=0.10", "nanobind >=2.0", "conan >=2.10"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "piper"
-version = "0.1.0"
+# Placeholder; stamped from the git tag by tools/setup/version.sh.
+version = "0.0.0"
 description = "Visual designer for control-system pipelines"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,3 +22,32 @@ cmake.build-type = "Release"
 BUILD_PY_BINDINGS = "ON"
 BUILD_APP         = "OFF"
 BUILD_TESTS       = "OFF"
+
+[tool.cibuildwheel]
+build-verbosity = 1
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+build = ["cp310-manylinux_*", "cp311-manylinux_*", "cp312-manylinux_*"]
+
+[tool.cibuildwheel.config-settings]
+"wheel.py-api" = "cp312"
+"cmake.define.CMAKE_CI_BUILD"       = true
+"cmake.define.CMAKE_FIND_ROOT_PATH" = "/tmp/piper_build_config"
+"cmake.define.CMAKE_TOOLCHAIN_FILE" = "/tmp/piper_build_config/toolchain.cmake"
+
+[[tool.cibuildwheel.overrides]]
+# nanobind does not support the Stable ABI for Python < 3.12.
+select = "cp3{10,11}-*"
+config-settings = { "cmake.define.CMAKE_CI_BUILD" = true, "cmake.define.CMAKE_FIND_ROOT_PATH" = "/tmp/piper_build_config", "cmake.define.CMAKE_TOOLCHAIN_FILE" = "/tmp/piper_build_config/toolchain.cmake" }
+
+[tool.cibuildwheel.linux]
+# CMAKE_CI_BUILD skips the in-tree setup_build.sh; run it (and version.sh) here.
+before-all = [
+  "pipx install conan",
+  "./setup_build.sh /tmp/piper_build_config",
+  "./tools/setup/version.sh",
+]
+repair-wheel-command = [
+  "auditwheel repair --zip-compression-level=9 -w {dest_dir} {wheel}",
+  "pipx run abi3audit --strict --report {dest_dir}/*.whl",
+]

--- a/setup_build.sh
+++ b/setup_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SOURCE_DIR=$(dirname "$(realpath $0)")
+SOURCE_DIR=$(dirname "$(realpath "$0")")
 
 usage() {
     cat <<EOF
@@ -71,7 +71,6 @@ if [[ "$(printf '%s\n' "$MIN_CONAN_VERSION" "$INSTALLED_CONAN_VERSION" | sort -V
 fi
 
 mkdir -p "$build_dir"
-echo "$build_dir"
 
 OS=$(uname -s)
 
@@ -164,7 +163,9 @@ CROSS_EOF
 else
     source "$SOURCE_DIR/tools/setup/detect_compiler.sh"
 
-    conan profile detect --force > /dev/null 2>&1
+    if ! conan profile path default > /dev/null 2>&1; then
+        conan profile detect > /dev/null 2>&1
+    fi
     ARCH_NAME=$(conan profile show -cx host | grep "arch=" | cut -d'=' -f2)
 
     echo "Architecture for Conan: $ARCH_NAME"

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -3,15 +3,20 @@ add_executable(piper_core_test
     bundle-t.cc
     builtin_nodes-t.cc
     color-t.cc
+    command_regression-t.cc
     diagnostics-t.cc
     example_load-t.cc
     format_pass-t.cc
+    label_links-t.cc
+    load_validation-t.cc
     mode_roundtrip-t.cc
     registry_roundtrip-t.cc
     roundtrip-t.cc
+    stage_order-t.cc
     theme-t.cc
     typecheck-t.cc
     undo-t.cc
+    vec-t.cc
 )
 target_link_libraries(piper_core_test PRIVATE
     piper_core

--- a/tests/core/command_regression-t.cc
+++ b/tests/core/command_regression-t.cc
@@ -1,0 +1,112 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "piper/command_stack.h"
+#include "piper/commands.h"
+#include "piper/graph.h"
+
+using namespace piper;
+
+namespace command_regression_test
+{
+    NodeType make_node_type()
+    {
+        NodeType nt;
+        nt.type = "Simple";
+        nt.attributes = {
+            { "in",  "float", AttributeSpec::Role::Input,  "" },
+            { "out", "float", AttributeSpec::Role::Output, "" },
+        };
+        return nt;
+    }
+}
+
+using command_regression_test::make_node_type;
+
+// Apply over an existing same-name stage is a no-op; revert must not
+// delete the pre-existing stage.
+TEST(CommandRegression, AddStageDuplicateRevertKeepsExisting)
+{
+    Graph g;
+    rgba const original = rgba::from_components(0xAA, 0xBB, 0xCC, 0xFF);
+    ASSERT_TRUE(g.add_stage({ "control", original }));
+
+    CommandStack stack;
+    stack.push(std::make_unique<AddStageCommand>(
+                   Stage{ "control", rgba::from_components(0x01, 0x02, 0x03, 0xFF) }),
+               g);
+    ASSERT_EQ(g.stages().size(), 1u);
+
+    stack.undo(g);
+    ASSERT_EQ(g.stages().size(), 1u) << "pre-existing stage deleted by duplicate revert";
+    EXPECT_EQ(g.stages()[0].name,  "control");
+    EXPECT_EQ(g.stages()[0].color, original);
+}
+
+TEST(CommandRegression, AddModeProfileDuplicateRevertKeepsExisting)
+{
+    Graph g;
+    ModeProfile existing;
+    existing.name        = "default";
+    existing.per_node[1] = "enable";
+    ASSERT_TRUE(g.add_mode_profile(existing));
+
+    CommandStack stack;
+    ModeProfile dup;
+    dup.name = "default";
+    stack.push(std::make_unique<AddModeProfileCommand>(dup), g);
+    ASSERT_EQ(g.mode_profiles().size(), 1u);
+
+    stack.undo(g);
+    ASSERT_EQ(g.mode_profiles().size(), 1u)
+        << "pre-existing profile deleted by duplicate revert";
+    EXPECT_EQ(g.mode_profiles()[0].name, "default");
+    EXPECT_EQ(g.mode_profiles()[0].per_node, existing.per_node);
+}
+
+TEST(CommandRegression, NonDuplicateAddStageRevertRemovesStage)
+{
+    Graph g;
+    CommandStack stack;
+    stack.push(std::make_unique<AddStageCommand>(Stage{ "fresh", rgba{} }), g);
+    ASSERT_EQ(g.stages().size(), 1u);
+    stack.undo(g);
+    EXPECT_TRUE(g.stages().empty());
+}
+
+// revision(): +1 on every push (including merged pushes), undo, redo.
+TEST(CommandRegression, RevisionCountsPushUndoRedo)
+{
+    Graph g;
+    auto type = make_node_type();
+    CommandStack stack;
+    EXPECT_EQ(stack.revision(), 0u);
+
+    stack.push(std::make_unique<AddNodeCommand>(type, "n", "", Point{}), g);
+    EXPECT_EQ(stack.revision(), 1u);
+    NodeId const id = g.nodes()[0].id;
+
+    // Merged pushes inside a group still bump the revision each time.
+    stack.open_group();
+    stack.push(std::make_unique<MoveNodeCommand>(id, Point{ 1.0f, 1.0f }), g);
+    EXPECT_EQ(stack.revision(), 2u);
+    stack.push(std::make_unique<MoveNodeCommand>(id, Point{ 2.0f, 2.0f }), g);
+    EXPECT_EQ(stack.revision(), 3u);
+    stack.close_group();
+    EXPECT_EQ(stack.revision(), 3u);
+
+    stack.undo(g);
+    EXPECT_EQ(stack.revision(), 4u);
+    stack.redo(g);
+    EXPECT_EQ(stack.revision(), 5u);
+}
+
+TEST(CommandRegression, RevisionUnchangedByEmptyUndoRedo)
+{
+    Graph g;
+    CommandStack stack;
+    stack.undo(g);
+    stack.redo(g);
+    EXPECT_EQ(stack.revision(), 0u);
+}

--- a/tests/core/diagnostics-t.cc
+++ b/tests/core/diagnostics-t.cc
@@ -275,6 +275,77 @@ TEST(LoadDiagnostic, DuplicateNodeId)
     EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::DuplicateNodeId));
 }
 
+TEST(LoadDiagnostic, DuplicateLinkId)
+{
+    NodeRegistry r;
+    auto simple = make_simple_type();
+    r.add(simple);
+
+    std::string text = R"({
+        "version": 2,
+        "nodes": [
+            {"id": 1, "type": "Simple", "name": "a", "stage": "", "pos": [0,0],
+             "attrs": [{"name": "out", "data_type": "float", "role": "output"}]},
+            {"id": 2, "type": "Simple", "name": "b", "stage": "", "pos": [0,0],
+             "attrs": [{"name": "in", "data_type": "float", "role": "input"}]}
+        ],
+        "links": [
+            {"id": 1, "from": {"node": 1, "attr": "out"}, "to": {"node": 2, "attr": "in"},
+             "data_type": "float"},
+            {"id": 1, "from": {"node": 1, "attr": "out"}, "to": {"node": 2, "attr": "in"},
+             "data_type": "float"}
+        ],
+        "stages": [],
+        "modes": []
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::DuplicateLinkId));
+    EXPECT_EQ(loaded.graph.links().size(), 1u);
+}
+
+TEST(LoadDiagnostic, DuplicateStageName)
+{
+    NodeRegistry r;
+
+    std::string text = R"({
+        "version": 2,
+        "nodes": [],
+        "links": [],
+        "stages": [
+            {"name": "control", "color": "#FF0000FF"},
+            {"name": "control", "color": "#00FF00FF"}
+        ],
+        "modes": []
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::DuplicateStageName));
+    // First entry kept.
+    ASSERT_EQ(loaded.graph.stages().size(), 1u);
+    EXPECT_EQ(loaded.graph.stages()[0].color.value, 0xFF0000FFu);
+}
+
+TEST(LoadDiagnostic, DuplicateProfileName)
+{
+    NodeRegistry r;
+
+    std::string text = R"({
+        "version": 2,
+        "nodes": [],
+        "links": [],
+        "stages": [],
+        "modes": [
+            {"name": "default", "per_node": []},
+            {"name": "default", "per_node": []}
+        ]
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::DuplicateProfileName));
+    EXPECT_EQ(loaded.graph.mode_profiles().size(), 1u);
+}
+
 TEST(LoadDiagnostic, AttributeAdded)
 {
     // Saved graph has an "in"+"out" attribute, but the registry was

--- a/tests/core/label_links-t.cc
+++ b/tests/core/label_links-t.cc
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include "piper/label.h"
+#include "piper/registry.h"
+#include "piper/serialize_v2.h"
+
+#include "test_helpers.h"
+
+using namespace piper;
+using piper::fixtures::any_of_kind;
+using piper::fixtures::make_simple_type;
+
+// A node wired to a first-class Label (link endpoint attr "pin") must
+// survive serialize -> deserialize with the link intact and zero
+// diagnostics. Labels now parse before links; previously every such
+// link was dropped as LinkOrphanedNode.
+TEST(LabelLinks, RoundTripPreservesLabelLinks)
+{
+    NodeRegistry r;
+    auto simple = make_simple_type();
+    r.add(simple);
+
+    Graph g;
+    auto a_id   = g.add_node(simple, "a", "", Point{ 0.0f, 0.0f });
+    auto b_id   = g.add_node(simple, "b", "", Point{ 3.0f, 0.0f });
+    auto in_id  = g.add_label(LabelKind::In,  "tap", Point{ 1.0f, 0.0f });
+    auto out_id = g.add_label(LabelKind::Out, "tap", Point{ 2.0f, 0.0f });
+
+    auto l1 = g.add_link({ a_id, "out" }, { in_id, label_pin_name }, "float");
+    auto l2 = g.add_link({ out_id, label_pin_name }, { b_id, "in" }, "float");
+    ASSERT_NE(l1, invalid_link_id);
+    ASSERT_NE(l2, invalid_link_id);
+
+    auto loaded = v2::deserialize(v2::serialize(g), r);
+
+    EXPECT_TRUE(loaded.diagnostics.empty())
+        << "unexpected diagnostics on label-link round-trip";
+    ASSERT_EQ(loaded.graph.labels().size(), 2u);
+    ASSERT_EQ(loaded.graph.links().size(),  2u);
+
+    Link const* la = loaded.graph.find_link(l1);
+    Link const* lb = loaded.graph.find_link(l2);
+    ASSERT_NE(la, nullptr);
+    ASSERT_NE(lb, nullptr);
+    EXPECT_EQ(la->from.node, a_id);
+    EXPECT_EQ(la->from.attr, "out");
+    EXPECT_EQ(la->to.node,   in_id);
+    EXPECT_EQ(la->to.attr,   label_pin_name);
+    EXPECT_EQ(la->data_type, "float");
+    EXPECT_EQ(lb->from.node, out_id);
+    EXPECT_EQ(lb->from.attr, label_pin_name);
+    EXPECT_EQ(lb->to.node,   b_id);
+    EXPECT_EQ(lb->to.attr,   "in");
+    EXPECT_EQ(lb->data_type, "float");
+}
+
+// Two same-name labels with out-of-order ids and different colors:
+// after load both must carry the SMALLEST-id label's color, with a
+// LabelClusterRepaired diagnostic.
+TEST(LabelLinks, RepairLabelClustersAdoptsSmallestIdColor)
+{
+    NodeRegistry r;
+
+    std::string const text = R"({
+        "version": 3,
+        "pipelines": [{
+            "nodes": [],
+            "links": [],
+            "stages": [],
+            "modes": [],
+            "labels": [
+                { "id": 9, "kind": "in",  "name": "tap", "pos": [0, 0],
+                  "color": "#AABBCCDD" },
+                { "id": 3, "kind": "out", "name": "tap", "pos": [1, 0],
+                  "color": "#11223344" }
+            ]
+        }]
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics,
+                            Diagnostic::Kind::LabelClusterRepaired));
+
+    Label const* high = loaded.graph.find_label(9);
+    Label const* low  = loaded.graph.find_label(3);
+    ASSERT_NE(high, nullptr);
+    ASSERT_NE(low,  nullptr);
+    EXPECT_EQ(low->color.value,  0x11223344u);
+    EXPECT_EQ(high->color.value, 0x11223344u) << "cluster must adopt smallest-id color";
+}
+
+TEST(LabelLinks, ConsistentClusterLoadsWithoutRepairDiagnostic)
+{
+    NodeRegistry r;
+    Graph g;
+    auto a_id = g.add_label(LabelKind::In,  "tap", Point{});
+    auto b_id = g.add_label(LabelKind::Out, "tap", Point{});
+    rgba const c = rgba::from_components(0x12, 0x34, 0x56, 0x78);
+    g.set_label_color(a_id, c);
+    g.set_label_color(b_id, c);
+
+    auto loaded = v2::deserialize(v2::serialize(g), r);
+    EXPECT_FALSE(any_of_kind(loaded.diagnostics,
+                             Diagnostic::Kind::LabelClusterRepaired));
+    EXPECT_TRUE(loaded.diagnostics.empty());
+}

--- a/tests/core/load_validation-t.cc
+++ b/tests/core/load_validation-t.cc
@@ -1,0 +1,210 @@
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "piper/registry.h"
+#include "piper/serialize_v2.h"
+
+#include "test_helpers.h"
+
+using namespace piper;
+using piper::fixtures::any_of_kind;
+using piper::fixtures::make_simple_type;
+
+// ---- Id validation ----
+
+TEST(LoadValidation, NodeIdZeroIsSchemaErrorAndSkipped)
+{
+    NodeRegistry r;
+    auto simple = make_simple_type();
+    r.add(simple);
+
+    std::string const text = R"({
+        "version": 2,
+        "nodes": [
+            {"id": 0, "type": "Simple", "name": "zero", "stage": "", "pos": [0,0], "attrs": []}
+        ],
+        "links": [],
+        "stages": [],
+        "modes": []
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_TRUE(loaded.graph.nodes().empty());
+}
+
+TEST(LoadValidation, NegativeNodeIdSkippedAndAllocatorStaysValid)
+{
+    NodeRegistry r;
+    auto simple = make_simple_type();
+    r.add(simple);
+
+    // Pre-fix, -1 read as uint64 max wrapped the allocator to the
+    // invalid sentinel 0; subsequently added nodes collided.
+    std::string const text = R"({
+        "version": 2,
+        "nodes": [
+            {"id": -1, "type": "Simple", "name": "neg", "stage": "", "pos": [0,0], "attrs": []},
+            {"id": 3,  "type": "Simple", "name": "ok",  "stage": "", "pos": [0,0], "attrs": []}
+        ],
+        "links": [],
+        "stages": [],
+        "modes": []
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    ASSERT_EQ(loaded.graph.nodes().size(), 1u);
+    EXPECT_EQ(loaded.graph.nodes()[0].id, 3u);
+
+    auto first  = loaded.graph.add_node(simple, "fresh_a", "", Point{});
+    auto second = loaded.graph.add_node(simple, "fresh_b", "", Point{});
+    EXPECT_NE(first,  invalid_node_id);
+    EXPECT_NE(second, invalid_node_id);
+    EXPECT_GT(first,  3u);
+    EXPECT_NE(first,  second);
+}
+
+TEST(LoadValidation, LinkIdZeroIsSchemaErrorAndSkipped)
+{
+    NodeRegistry r;
+    auto simple = make_simple_type();
+    r.add(simple);
+
+    std::string const text = R"({
+        "version": 2,
+        "nodes": [
+            {"id": 1, "type": "Simple", "name": "a", "stage": "", "pos": [0,0],
+             "attrs": [{"name": "out", "data_type": "float", "role": "output"}]},
+            {"id": 2, "type": "Simple", "name": "b", "stage": "", "pos": [0,0],
+             "attrs": [{"name": "in", "data_type": "float", "role": "input"}]}
+        ],
+        "links": [
+            {"id": 0, "from": {"node": 1, "attr": "out"},
+                      "to":   {"node": 2, "attr": "in"}, "data_type": "float"}
+        ],
+        "stages": [],
+        "modes": []
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_TRUE(loaded.graph.links().empty());
+
+    auto fresh = loaded.graph.add_link({ 1, "out" }, { 2, "in" }, "float");
+    EXPECT_NE(fresh, invalid_link_id);
+}
+
+TEST(LoadValidation, GraphInsertRejectsIdZero)
+{
+    Graph g;
+    Node n;
+    n.id   = invalid_node_id;
+    n.type = "Simple";
+    EXPECT_FALSE(g.insert_node(n));
+    EXPECT_TRUE(g.nodes().empty());
+
+    Link l;
+    l.id = invalid_link_id;
+    EXPECT_FALSE(g.insert_link(l));
+    EXPECT_TRUE(g.links().empty());
+}
+
+// ---- Malformed-field containment: per-item SchemaError, item
+// skipped, no exception escapes deserialize_bundle ----
+
+TEST(LoadValidation, StageNameAsIntIsContained)
+{
+    NodeRegistry r;
+    std::string const text = R"({
+        "version": 2,
+        "nodes": [],
+        "links": [],
+        "stages": [{"name": 5}],
+        "modes": []
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_TRUE(loaded.graph.stages().empty());
+}
+
+TEST(LoadValidation, ModeNameAsIntIsContained)
+{
+    NodeRegistry r;
+    std::string const text = R"({
+        "version": 2,
+        "nodes": [],
+        "links": [],
+        "stages": [],
+        "modes": [{"name": 7, "per_node": []}]
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_TRUE(loaded.graph.mode_profiles().empty());
+}
+
+TEST(LoadValidation, AnnotationPosAsStringsIsContained)
+{
+    NodeRegistry r;
+    std::string const text = R"({
+        "version": 2,
+        "nodes": [],
+        "links": [],
+        "stages": [],
+        "modes": [],
+        "annotations": [{"id": 1, "pos": ["a", "b"]}]
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_TRUE(loaded.graph.annotations().empty());
+}
+
+TEST(LoadValidation, LabelIdAsStringIsContained)
+{
+    NodeRegistry r;
+    std::string const text = R"({
+        "version": 3,
+        "nodes": [],
+        "links": [],
+        "stages": [],
+        "modes": [],
+        "labels": [{"id": "x", "kind": "in", "name": "tap"}]
+    })";
+
+    auto loaded = v2::deserialize(text, r);
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_TRUE(loaded.graph.labels().empty());
+}
+
+// ---- Document-shape errors throw std::runtime_error ----
+
+TEST(LoadValidation, VersionAsStringThrows)
+{
+    NodeRegistry r;
+    EXPECT_THROW(v2::deserialize_bundle(R"({"version": "3", "pipelines": []})", r),
+                 std::runtime_error);
+}
+
+TEST(LoadValidation, MissingVersionThrows)
+{
+    NodeRegistry r;
+    EXPECT_THROW(v2::deserialize_bundle(R"({"pipelines": []})", r),
+                 std::runtime_error);
+}
+
+TEST(LoadValidation, TopLevelArrayThrows)
+{
+    NodeRegistry r;
+    EXPECT_THROW(v2::deserialize_bundle(R"([1, 2, 3])", r), std::runtime_error);
+}
+
+TEST(LoadValidation, PipelinesAsNumberThrows)
+{
+    NodeRegistry r;
+    EXPECT_THROW(v2::deserialize_bundle(R"({"version": 3, "pipelines": 5})", r),
+                 std::runtime_error);
+}

--- a/tests/core/roundtrip-t.cc
+++ b/tests/core/roundtrip-t.cc
@@ -268,21 +268,69 @@ TEST(SerializeV2, RoundTripPreservesLabels)
     auto a_id = g.add_label(LabelKind::In,  "tap",     Point{ 100.0f, 200.0f });
     auto b_id = g.add_label(LabelKind::Out, "tap",     Point{ 500.0f, 200.0f });
     auto c_id = g.add_label(LabelKind::In,  "feedback", Point{   0.0f,   0.0f });
-    (void)c_id;
+
+    rgba const tap_color = rgba::from_components(0x12, 0x34, 0x56, 0x78);
+    g.set_label_color(a_id, tap_color);
+    g.set_label_color(b_id, tap_color);
+    rgba const default_color = Label{}.color;
 
     auto loaded = v2::deserialize(v2::serialize(g), registry);
     ASSERT_EQ(loaded.graph.labels().size(), 3u);
 
     Label const* la = loaded.graph.find_label(a_id);
     Label const* lb = loaded.graph.find_label(b_id);
+    Label const* lc = loaded.graph.find_label(c_id);
     ASSERT_NE(la, nullptr);
     ASSERT_NE(lb, nullptr);
+    ASSERT_NE(lc, nullptr);
     EXPECT_EQ(la->kind, LabelKind::In);
     EXPECT_EQ(la->name, "tap");
     Point const a_pos{ 100.0f, 200.0f };
     EXPECT_EQ(la->pos, a_pos);
+    EXPECT_EQ(la->color, tap_color);
     EXPECT_EQ(lb->kind, LabelKind::Out);
     EXPECT_EQ(lb->name, "tap");
+    EXPECT_EQ(lb->color, tap_color);
+    EXPECT_EQ(lc->color, default_color);
+}
+
+TEST(SerializeV2, RoundTripPreservesUnicodeText)
+{
+    auto registry = default_registry();
+    Graph g;
+
+    std::string const stage_name = "étape-Δt";
+    std::string const node_name  = "électrovanne";
+    std::string const label_name = "señal-Δt";
+    std::string const anno_text  = "résumé Δt ±5µs";
+
+    g.add_stage({ stage_name, rgba::from_components(0xFF, 0x00, 0x00, 0xFF) });
+    auto bus     = make_bus_type();
+    auto node_id = g.add_node(bus, node_name, stage_name, Point{});
+    auto lbl_id  = g.add_label(LabelKind::In, label_name, Point{});
+
+    Annotation a;
+    a.text       = anno_text;
+    auto anno_id = g.add_annotation(a);
+
+    auto loaded = v2::deserialize(v2::serialize(g), registry);
+    EXPECT_TRUE(loaded.diagnostics.empty());
+
+    Node const* n = loaded.graph.find_node(node_id);
+    ASSERT_NE(n, nullptr);
+    EXPECT_EQ(n->name,  node_name);
+    EXPECT_EQ(n->stage, stage_name);
+
+    ASSERT_EQ(loaded.graph.stages().size(), 1u);
+    EXPECT_EQ(loaded.graph.stages()[0].name, stage_name);
+
+    Label const* l = loaded.graph.find_label(lbl_id);
+    ASSERT_NE(l, nullptr);
+    EXPECT_EQ(l->name, label_name);
+
+    Annotation const* an = loaded.graph.find_annotation(anno_id);
+    ASSERT_NE(an, nullptr);
+    EXPECT_EQ(an->text, anno_text);
 }
 
 TEST(SerializeV2, MigratesOldLabelNodes)

--- a/tests/core/stage_order-t.cc
+++ b/tests/core/stage_order-t.cc
@@ -1,0 +1,109 @@
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "piper/graph.h"
+
+using namespace piper;
+
+namespace stage_order_test
+{
+    Graph make_graph_abc()
+    {
+        Graph g;
+        g.add_stage({ "a", rgba::from_components(0xFF, 0x00, 0x00, 0xFF) });
+        g.add_stage({ "b", rgba::from_components(0x00, 0xFF, 0x00, 0xFF) });
+        g.add_stage({ "c", rgba::from_components(0x00, 0x00, 0xFF, 0xFF) });
+        return g;
+    }
+
+    std::vector<std::string> stage_names(Graph const& g)
+    {
+        std::vector<std::string> names;
+        for (auto const& s : g.stages())
+        {
+            names.push_back(s.name);
+        }
+        return names;
+    }
+}
+
+using stage_order_test::make_graph_abc;
+using stage_order_test::stage_names;
+
+TEST(StageOrder, MoveStageUpSwapsWithPredecessor)
+{
+    Graph g = make_graph_abc();
+    EXPECT_TRUE(g.move_stage_up("b"));
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "b", "a", "c" }));
+}
+
+TEST(StageOrder, MoveStageUpAtTopReturnsFalse)
+{
+    Graph g = make_graph_abc();
+    EXPECT_FALSE(g.move_stage_up("a"));
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "a", "b", "c" }));
+}
+
+TEST(StageOrder, MoveStageUpUnknownNameReturnsFalse)
+{
+    Graph g = make_graph_abc();
+    EXPECT_FALSE(g.move_stage_up("ghost"));
+}
+
+TEST(StageOrder, MoveStageDownSwapsWithSuccessor)
+{
+    Graph g = make_graph_abc();
+    EXPECT_TRUE(g.move_stage_down("b"));
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "a", "c", "b" }));
+}
+
+TEST(StageOrder, MoveStageDownAtBottomReturnsFalse)
+{
+    Graph g = make_graph_abc();
+    EXPECT_FALSE(g.move_stage_down("c"));
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "a", "b", "c" }));
+}
+
+TEST(StageOrder, MoveStageDownUnknownNameReturnsFalse)
+{
+    Graph g = make_graph_abc();
+    EXPECT_FALSE(g.move_stage_down("ghost"));
+}
+
+TEST(StageOrder, SetStagesOrderSkipsUnknownAndAppendsLeftovers)
+{
+    Graph g = make_graph_abc();
+    g.set_stages_order({ "c", "ghost", "a" });
+    // "ghost" skipped; leftover "b" appended in existing order.
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "c", "a", "b" }));
+}
+
+TEST(StageOrder, SetStagesOrderEmptyKeepsAllStages)
+{
+    Graph g = make_graph_abc();
+    g.set_stages_order({});
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "a", "b", "c" }));
+}
+
+TEST(StageOrder, InsertStageAtClampsOutOfRangeIndex)
+{
+    Graph g = make_graph_abc();
+    EXPECT_TRUE(g.insert_stage_at({ "z", rgba{} }, 99));
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "a", "b", "c", "z" }));
+}
+
+TEST(StageOrder, InsertStageAtPlacesAtIndex)
+{
+    Graph g = make_graph_abc();
+    EXPECT_TRUE(g.insert_stage_at({ "z", rgba{} }, 1));
+    EXPECT_EQ(stage_names(g), (std::vector<std::string>{ "a", "z", "b", "c" }));
+}
+
+TEST(StageOrder, InsertStageAtRejectsDuplicateName)
+{
+    Graph g = make_graph_abc();
+    EXPECT_FALSE(g.insert_stage_at({ "b", rgba{} }, 0));
+    EXPECT_EQ(g.stages().size(), 3u);
+}

--- a/tests/core/theme-t.cc
+++ b/tests/core/theme-t.cc
@@ -140,6 +140,46 @@ TEST(Theme, DataThemeJsonLoadsWithoutDiagnostics)
     EXPECT_NE(loaded.theme.type_colors.find("vec3"),    loaded.theme.type_colors.end());
 }
 
+TEST(Theme, NegativeGridSpacingKeepsDefaultWithDiagnostic)
+{
+    auto loaded = load_theme_from_string(R"({
+        "version": 2,
+        "canvas": { "grid": { "spacing": -10 } }
+    })");
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_EQ(loaded.theme.grid_spacing, Theme{}.grid_spacing);
+}
+
+TEST(Theme, ZeroGridSpacingKeepsDefaultWithDiagnostic)
+{
+    auto loaded = load_theme_from_string(R"({
+        "version": 2,
+        "canvas": { "grid": { "spacing": 0 } }
+    })");
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_EQ(loaded.theme.grid_spacing, Theme{}.grid_spacing);
+}
+
+TEST(Theme, OversizedFontClampedTo96WithDiagnostic)
+{
+    auto loaded = load_theme_from_string(R"({
+        "version": 2,
+        "font": { "size": 200 }
+    })");
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_EQ(loaded.theme.font_size, 96.0f);
+}
+
+TEST(Theme, UndersizedFontClampedTo8WithDiagnostic)
+{
+    auto loaded = load_theme_from_string(R"({
+        "version": 2,
+        "font": { "size": 4 }
+    })");
+    EXPECT_TRUE(any_of_kind(loaded.diagnostics, Diagnostic::Kind::SchemaError));
+    EXPECT_EQ(loaded.theme.font_size, 8.0f);
+}
+
 TEST(Theme, WrongTypeColorValueFiresSchemaError)
 {
     auto loaded = load_theme_from_string(R"({"version": 2, "canvas": {"bg": 255}})");

--- a/tests/core/vec-t.cc
+++ b/tests/core/vec-t.cc
@@ -1,0 +1,47 @@
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "piper/vec.h"
+
+using namespace piper;
+
+TEST(ParseVec3f, ParsesPlainTriple)
+{
+    Vec3<float> const v = parse_vec3f("1,2,3");
+    EXPECT_FLOAT_EQ(v.x, 1.0f);
+    EXPECT_FLOAT_EQ(v.y, 2.0f);
+    EXPECT_FLOAT_EQ(v.z, 3.0f);
+}
+
+TEST(ParseVec3f, ParsesNegativeAndFractional)
+{
+    Vec3<float> const v = parse_vec3f("-1.5,0.25,-3e2");
+    EXPECT_FLOAT_EQ(v.x, -1.5f);
+    EXPECT_FLOAT_EQ(v.y, 0.25f);
+    EXPECT_FLOAT_EQ(v.z, -300.0f);
+}
+
+TEST(ParseVec3f, ToleratesWhitespace)
+{
+    Vec3<float> const v = parse_vec3f("  1.5 , -2.5 ,  3.25  ");
+    EXPECT_FLOAT_EQ(v.x, 1.5f);
+    EXPECT_FLOAT_EQ(v.y, -2.5f);
+    EXPECT_FLOAT_EQ(v.z, 3.25f);
+}
+
+TEST(ParseVec3f, ThrowsOnTwoComponents)
+{
+    EXPECT_THROW(parse_vec3f("1,2"), std::runtime_error);
+}
+
+TEST(ParseVec3f, ThrowsOnGarbage)
+{
+    EXPECT_THROW(parse_vec3f("abc"), std::invalid_argument);
+    EXPECT_THROW(parse_vec3f(""), std::invalid_argument);
+}
+
+TEST(ParseVec3f, ThrowsOnWrongSeparator)
+{
+    EXPECT_THROW(parse_vec3f("1;2;3"), std::runtime_error);
+}

--- a/tests/engine/CMakeLists.txt
+++ b/tests/engine/CMakeLists.txt
@@ -1,13 +1,16 @@
 add_executable(piper_engine_test
+    build_diagnostics-t.cc
     build_smoke-t.cc
     cycle-t.cc
     declare_io_failure-t.cc
     external_io-t.cc
+    kernels-t.cc
     label_resolver-t.cc
     missing_factory-t.cc
     mode_gating-t.cc
     motor_control_smoke-t.cc
     multi_stage_tick-t.cc
+    pid-t.cc
     single_stage_tick-t.cc
 )
 target_link_libraries(piper_engine_test PRIVATE

--- a/tests/engine/build_diagnostics-t.cc
+++ b/tests/engine/build_diagnostics-t.cc
@@ -1,0 +1,300 @@
+#include <memory>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "piper/builtin_nodes.h"
+#include "piper/graph.h"
+#include "piper/registry.h"
+#include "piper/stage.h"
+
+#include "piper/engine/builtin_steps.h"
+#include "piper/engine/engine.h"
+#include "piper/engine/external_io.h"
+#include "piper/engine/registry.h"
+
+using piper::Graph;
+using piper::NodeRegistry;
+using piper::PinRef;
+using piper::Point;
+using piper::engine::BuildDiagnostic;
+using piper::engine::Engine;
+using piper::engine::StepRegistry;
+
+namespace build_diag_test
+{
+    bool has_kind(std::vector<BuildDiagnostic> const& diags,
+                  BuildDiagnostic::Kind k)
+    {
+        for (auto const& d : diags)
+        {
+            if (d.kind == k)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    BuildDiagnostic const* find_kind(std::vector<BuildDiagnostic> const& diags,
+                                     BuildDiagnostic::Kind k)
+    {
+        for (auto const& d : diags)
+        {
+            if (d.kind == k)
+            {
+                return &d;
+            }
+        }
+        return nullptr;
+    }
+
+    // Not the engine's external IO step: external_io_kind() stays None.
+    class FakeExternalInput final : public piper::engine::Step
+    {
+    public:
+        void declare_io() override { declare_output<float>("out", out_); }
+        void compute(piper::engine::Stage) override {}
+
+    private:
+        float out_{};
+    };
+}
+
+using build_diag_test::find_kind;
+using build_diag_test::has_kind;
+using build_diag_test::FakeExternalInput;
+
+TEST(EngineBuildDiagnostics, MissingInputNamesNodeAndPin)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* cf = nr.find("constant<float>");
+    auto const* ad = nr.find("add<float>");
+
+    auto c_id   = g.add_node(*cf, "src", "control", Point{});
+    auto add_id = g.add_node(*ad, "sum", "control", Point{});
+    g.add_link(PinRef{ c_id, "out" }, PinRef{ add_id, "a" }, "float");
+    // "b" left unwired.
+
+    StepRegistry sr;
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    EXPECT_FALSE(res.ok);
+    BuildDiagnostic const* d =
+        find_kind(res.diagnostics, BuildDiagnostic::Kind::MissingInput);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->node_id,   add_id);
+    EXPECT_EQ(d->attr_name, "b");
+}
+
+TEST(EngineBuildDiagnostics, OptionalInputUnwiredBuildsOk)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* cf  = nr.find("constant<float>");
+    auto const* pid = nr.find("pid<float>");
+
+    auto pid_id = g.add_node(*pid, "pid", "control", Point{});
+    char const* required_pins[] = { "setpoint", "measured", "kp", "ki", "kd" };
+    for (char const* pin : required_pins)
+    {
+        auto c = g.add_node(*cf, pin, "control", Point{});
+        g.add_link(PinRef{ c, "out" }, PinRef{ pid_id, pin }, "float");
+    }
+    // Optional "dt_in" left unwired.
+
+    StepRegistry sr;
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    EXPECT_TRUE(res.ok);
+    EXPECT_TRUE(res.diagnostics.empty());
+}
+
+TEST(EngineBuildDiagnostics, DuplicateInputWiringFails)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* cf = nr.find("constant<float>");
+    auto const* ad = nr.find("add<float>");
+
+    auto c1     = g.add_node(*cf, "c1",  "control", Point{});
+    auto c2     = g.add_node(*cf, "c2",  "control", Point{});
+    auto add_id = g.add_node(*ad, "sum", "control", Point{});
+    g.add_link(PinRef{ c1, "out" }, PinRef{ add_id, "a" }, "float");
+    g.add_link(PinRef{ c2, "out" }, PinRef{ add_id, "a" }, "float");
+    g.add_link(PinRef{ c1, "out" }, PinRef{ add_id, "b" }, "float");
+
+    StepRegistry sr;
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    EXPECT_FALSE(res.ok);
+    BuildDiagnostic const* d =
+        find_kind(res.diagnostics, BuildDiagnostic::Kind::DuplicateInputWiring);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->node_id,   add_id);
+    EXPECT_EQ(d->attr_name, "a");
+}
+
+TEST(EngineBuildDiagnostics, ThrowingFactoryEmitsStepConstructionFailed)
+{
+    piper::NodeType boom;
+    boom.type = "boom";
+    boom.attributes = {
+        { "out", "float", piper::AttributeSpec::Role::Output, "" },
+    };
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto boom_id = g.add_node(boom, "b", "control", Point{});
+
+    StepRegistry sr;
+    sr.add("boom", []() -> std::shared_ptr<piper::engine::Step>
+    {
+        throw std::runtime_error("kaboom");
+    });
+
+    Engine e;
+    Engine::BuildResult res;
+    EXPECT_NO_THROW(res = e.build(g, sr));
+    EXPECT_FALSE(res.ok);
+    BuildDiagnostic const* d =
+        find_kind(res.diagnostics, BuildDiagnostic::Kind::StepConstructionFailed);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->node_id, boom_id);
+}
+
+TEST(EngineBuildDiagnostics, ForeignStepUnderExternalInputTypeEmitsFactoryTypeMismatch)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* ext = nr.find("external_input<float>");
+    auto ext_id = g.add_node(*ext, "knob", "control", Point{});
+    g.set_attr_value(ext_id, "name", "x");
+
+    // Registered first, so register_builtin_steps' duplicate add for
+    // the same type string is rejected and the foreign factory wins.
+    StepRegistry sr;
+    ASSERT_TRUE(sr.add("external_input<float>", []
+    {
+        return std::make_shared<FakeExternalInput>();
+    }));
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    EXPECT_FALSE(res.ok);
+    BuildDiagnostic const* d =
+        find_kind(res.diagnostics, BuildDiagnostic::Kind::FactoryTypeMismatch);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->node_id, ext_id);
+    // The foreign step must not be handed out as a typed handle.
+    EXPECT_EQ(e.input<float>("x"), nullptr);
+}
+
+TEST(EngineBuildDiagnostics, ProbeFloatBuildsAndPlays)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* cf = nr.find("constant<float>");
+    auto const* pb = nr.find("probe<float>");
+    ASSERT_NE(pb, nullptr);
+
+    auto c_id     = g.add_node(*cf, "src",   "control", Point{});
+    auto probe_id = g.add_node(*pb, "probe", "control", Point{});
+    g.set_attr_value(c_id, "value", "3.5");
+    g.add_link(PinRef{ c_id, "out" }, PinRef{ probe_id, "in" }, "float");
+
+    StepRegistry sr;
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    EXPECT_TRUE(res.ok);
+    EXPECT_TRUE(res.diagnostics.empty())
+        << "probe<float> should have a registered factory";
+    EXPECT_NE(e.step_for(probe_id), nullptr);
+    EXPECT_NO_THROW(e.play());
+}
+
+TEST(EngineContract, TickBeforeBuildIsNoOp)
+{
+    Engine e;
+    EXPECT_NO_THROW(e.tick("control"));
+    EXPECT_NO_THROW(e.play());
+    EXPECT_EQ(e.step_for(1), nullptr);
+}
+
+TEST(EngineContract, TickOnUnknownStageIsNoOp)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* cf = nr.find("constant<float>");
+    auto const* eo = nr.find("external_output<float>");
+
+    auto c_id = g.add_node(*cf, "src", "control", Point{});
+    auto o_id = g.add_node(*eo, "out", "control", Point{});
+    g.set_attr_value(c_id, "value", "7.0");
+    g.set_attr_value(o_id, "name", "p");
+    g.add_link(PinRef{ c_id, "out" }, PinRef{ o_id, "in" }, "float");
+
+    StepRegistry sr;
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    ASSERT_TRUE(res.ok);
+
+    auto const* probe = e.output<float>("p");
+    ASSERT_NE(probe, nullptr);
+
+    e.tick("ghost_stage");
+    EXPECT_FLOAT_EQ(probe->get(), 0.0f);
+
+    e.tick("control");
+    EXPECT_FLOAT_EQ(probe->get(), 7.0f);
+}
+
+TEST(EngineContract, StepForUnknownIdReturnsNullptr)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* cf = nr.find("constant<float>");
+    auto c_id = g.add_node(*cf, "src", "control", Point{});
+
+    StepRegistry sr;
+    piper::engine::register_builtin_steps(sr);
+
+    Engine e;
+    auto res = e.build(g, sr);
+    ASSERT_TRUE(res.ok);
+    EXPECT_NE(e.step_for(c_id), nullptr);
+    EXPECT_EQ(e.step_for(999999), nullptr);
+}

--- a/tests/engine/kernels-t.cc
+++ b/tests/engine/kernels-t.cc
@@ -1,0 +1,232 @@
+#include <stdint.h>
+
+#include <gtest/gtest.h>
+
+#include "piper/builtin_nodes.h"
+#include "piper/graph.h"
+#include "piper/registry.h"
+#include "piper/stage.h"
+
+#include "piper/vec.h"
+
+#include "piper/engine/builtin_steps.h"
+#include "piper/engine/engine.h"
+#include "piper/engine/external_io.h"
+#include "piper/engine/registry.h"
+
+using piper::Graph;
+using piper::NodeRegistry;
+using piper::PinRef;
+using piper::Point;
+using piper::Vec3;
+using piper::engine::Engine;
+using piper::engine::StepRegistry;
+
+namespace kernels_test
+{
+    struct Rig
+    {
+        NodeRegistry nr;
+        StepRegistry sr;
+        Graph        g;
+        Engine       e;
+
+        Rig()
+        {
+            piper::register_builtin_nodes(nr);
+            piper::engine::register_builtin_steps(sr);
+            g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+        }
+
+        piper::NodeId constant(char const* type, char const* value)
+        {
+            auto const* nt = nr.find(type);
+            auto id = g.add_node(*nt, "c", "control", Point{});
+            g.set_attr_value(id, "value", value);
+            return id;
+        }
+
+        piper::NodeId node(char const* type, char const* name)
+        {
+            auto const* nt = nr.find(type);
+            return g.add_node(*nt, name, "control", Point{});
+        }
+
+        bool build_ok()
+        {
+            return e.build(g, sr).ok;
+        }
+    };
+}
+
+using kernels_test::Rig;
+
+TEST(Kernels, AddFloat)
+{
+    Rig r;
+    auto a   = r.constant("constant<float>", "2.5");
+    auto b   = r.constant("constant<float>", "4.25");
+    auto sum = r.node("add<float>", "sum");
+    r.g.add_link(PinRef{ a, "out" }, PinRef{ sum, "a" }, "float");
+    r.g.add_link(PinRef{ b, "out" }, PinRef{ sum, "b" }, "float");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(sum)->output<float>("out"), 6.75f);
+}
+
+TEST(Kernels, SubtractFloat)
+{
+    Rig r;
+    auto a    = r.constant("constant<float>", "5.0");
+    auto b    = r.constant("constant<float>", "7.5");
+    auto diff = r.node("subtract<float>", "diff");
+    r.g.add_link(PinRef{ a, "out" }, PinRef{ diff, "a" }, "float");
+    r.g.add_link(PinRef{ b, "out" }, PinRef{ diff, "b" }, "float");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(diff)->output<float>("out"), -2.5f);
+}
+
+TEST(Kernels, MultiplyFloat)
+{
+    Rig r;
+    auto a    = r.constant("constant<float>", "3.0");
+    auto b    = r.constant("constant<float>", "-4.5");
+    auto prod = r.node("multiply<float>", "prod");
+    r.g.add_link(PinRef{ a, "out" }, PinRef{ prod, "a" }, "float");
+    r.g.add_link(PinRef{ b, "out" }, PinRef{ prod, "b" }, "float");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(prod)->output<float>("out"), -13.5f);
+}
+
+TEST(Kernels, AbsFloatNegativeInput)
+{
+    Rig r;
+    auto c = r.constant("constant<float>", "-3.5");
+    auto a = r.node("abs<float>", "abs");
+    r.g.add_link(PinRef{ c, "out" }, PinRef{ a, "in" }, "float");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(a)->output<float>("out"), 3.5f);
+}
+
+TEST(Kernels, AbsInt32NegativeInput)
+{
+    Rig r;
+    auto c = r.constant("constant<int32_t>", "-7");
+    auto a = r.node("abs<int32_t>", "abs");
+    r.g.add_link(PinRef{ c, "out" }, PinRef{ a, "in" }, "int32_t");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+    EXPECT_EQ(r.e.step_for(a)->output<int32_t>("out"), 7);
+}
+
+TEST(Kernels, ClampBelowInsideAbove)
+{
+    Rig r;
+    auto drive = r.node("external_input<float>", "drive");
+    r.g.set_attr_value(drive, "name", "drive");
+    auto cl = r.node("clamp<float>", "clamp");
+    r.g.set_attr_value(cl, "min", "-1.0");
+    r.g.set_attr_value(cl, "max", "1.0");
+    r.g.add_link(PinRef{ drive, "out" }, PinRef{ cl, "in" }, "float");
+
+    ASSERT_TRUE(r.build_ok());
+    auto* in = r.e.input<float>("drive");
+    ASSERT_NE(in, nullptr);
+
+    in->set(-5.0f);
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(cl)->output<float>("out"), -1.0f);
+
+    in->set(0.25f);
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(cl)->output<float>("out"), 0.25f);
+
+    in->set(9.0f);
+    r.e.tick("control");
+    EXPECT_FLOAT_EQ(r.e.step_for(cl)->output<float>("out"), 1.0f);
+}
+
+TEST(Kernels, CastFloatToInt32TruncatesTowardZero)
+{
+    Rig r;
+    auto pos      = r.constant("constant<float>", "2.9");
+    auto neg      = r.constant("constant<float>", "-2.9");
+    auto cast_pos = r.node("cast<int32_t>", "cast_pos");
+    auto cast_neg = r.node("cast<int32_t>", "cast_neg");
+    r.g.add_link(PinRef{ pos, "out" }, PinRef{ cast_pos, "in" }, "float");
+    r.g.add_link(PinRef{ neg, "out" }, PinRef{ cast_neg, "in" }, "float");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+    // static_cast<int32_t>(float) truncates toward zero.
+    EXPECT_EQ(r.e.step_for(cast_pos)->output<int32_t>("out"),  2);
+    EXPECT_EQ(r.e.step_for(cast_neg)->output<int32_t>("out"), -2);
+}
+
+TEST(Kernels, Mux3SelectsAndSaturates)
+{
+    Rig r;
+    auto in0 = r.constant("constant<float>", "10.0");
+    auto in1 = r.constant("constant<float>", "20.0");
+    auto in2 = r.constant("constant<float>", "30.0");
+    auto sel = r.node("external_input<int32_t>", "sel");
+    r.g.set_attr_value(sel, "name", "sel");
+    auto mux = r.node("mux3<float>", "mux");
+    r.g.add_link(PinRef{ in0, "out" }, PinRef{ mux, "in0" },    "float");
+    r.g.add_link(PinRef{ in1, "out" }, PinRef{ mux, "in1" },    "float");
+    r.g.add_link(PinRef{ in2, "out" }, PinRef{ mux, "in2" },    "float");
+    r.g.add_link(PinRef{ sel, "out" }, PinRef{ mux, "select" }, "int32_t");
+
+    ASSERT_TRUE(r.build_ok());
+    auto* select = r.e.input<int32_t>("sel");
+    ASSERT_NE(select, nullptr);
+
+    auto mux_out = [&]
+    {
+        r.e.tick("control");
+        return r.e.step_for(mux)->output<float>("out");
+    };
+
+    select->set(0);
+    EXPECT_FLOAT_EQ(mux_out(), 10.0f);
+    select->set(1);
+    EXPECT_FLOAT_EQ(mux_out(), 20.0f);
+    select->set(2);
+    EXPECT_FLOAT_EQ(mux_out(), 30.0f);
+    // Out-of-range selectors saturate to in0 / in2.
+    select->set(-5);
+    EXPECT_FLOAT_EQ(mux_out(), 10.0f);
+    select->set(99);
+    EXPECT_FLOAT_EQ(mux_out(), 30.0f);
+}
+
+TEST(Kernels, Vec3ConstantComponents)
+{
+    Rig r;
+    auto a   = r.constant("constant<vec3<float>>", "1,2,3");
+    auto b   = r.constant("constant<vec3<float>>", "10,20,30");
+    auto sum = r.node("add<vec3<float>>", "sum");
+    r.g.add_link(PinRef{ a, "out" }, PinRef{ sum, "a" }, "vec3<float>");
+    r.g.add_link(PinRef{ b, "out" }, PinRef{ sum, "b" }, "vec3<float>");
+
+    ASSERT_TRUE(r.build_ok());
+    r.e.tick("control");
+
+    Vec3<float> const src = r.e.step_for(a)->output<Vec3<float>>("out");
+    EXPECT_FLOAT_EQ(src.x, 1.0f);
+    EXPECT_FLOAT_EQ(src.y, 2.0f);
+    EXPECT_FLOAT_EQ(src.z, 3.0f);
+
+    Vec3<float> const v = r.e.step_for(sum)->output<Vec3<float>>("out");
+    EXPECT_FLOAT_EQ(v.x, 11.0f);
+    EXPECT_FLOAT_EQ(v.y, 22.0f);
+    EXPECT_FLOAT_EQ(v.z, 33.0f);
+}

--- a/tests/engine/label_resolver-t.cc
+++ b/tests/engine/label_resolver-t.cc
@@ -104,6 +104,99 @@ TEST(LabelResolver, NoLabelInForLabelOutFlagsError)
     EXPECT_TRUE(effective.empty());
 }
 
+TEST(LabelResolver, ChainedLabelClustersFlagError)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+    auto g            = make_graph_with_constant(nr);
+    auto src_id       = g.nodes().front().id;
+    auto const* probe = nr.find("external_output<float>");
+    auto probe_id     = g.add_node(*probe, "probe", "control", Point{ 5.0f, 0.0f });
+    auto in_b         = g.add_label(LabelKind::In,  "b", Point{ 1.0f, 0.0f });
+    auto out_b        = g.add_label(LabelKind::Out, "b", Point{ 2.0f, 0.0f });
+    auto in_a         = g.add_label(LabelKind::In,  "a", Point{ 3.0f, 0.0f });
+    auto out_a        = g.add_label(LabelKind::Out, "a", Point{ 4.0f, 0.0f });
+
+    // Cluster "a" is fed by cluster "b"'s label_out: label chaining.
+    g.add_link(PinRef{ src_id, "out" },                 PinRef{ in_b,     piper::label_pin_name }, "float");
+    g.add_link(PinRef{ out_b, piper::label_pin_name },  PinRef{ in_a,     piper::label_pin_name }, "float");
+    g.add_link(PinRef{ out_a, piper::label_pin_name },  PinRef{ probe_id, "in" },                  "float");
+
+    std::vector<BuildDiagnostic> diags;
+    bool has_error = false;
+    resolve_label_clusters(g, diags, has_error);
+
+    EXPECT_TRUE(has_error);
+    bool fed_by_label = false;
+    for (auto const& d : diags)
+    {
+        if (d.message.find("fed by another label") != std::string::npos)
+        {
+            fed_by_label = true;
+            EXPECT_EQ(d.node_id, in_a);
+        }
+    }
+    EXPECT_TRUE(fed_by_label);
+}
+
+TEST(LabelResolver, LabelInWithNoWiredSourceFlagsError)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+    Graph g;
+    g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+    auto const* probe = nr.find("external_output<float>");
+    auto probe_id     = g.add_node(*probe, "probe", "control", Point{ 2.0f, 0.0f });
+    auto in_id        = g.add_label(LabelKind::In,  "tap", Point{ 0.0f, 0.0f });
+    auto out_id       = g.add_label(LabelKind::Out, "tap", Point{ 1.0f, 0.0f });
+    g.add_link(PinRef{ out_id, piper::label_pin_name }, PinRef{ probe_id, "in" }, "float");
+
+    std::vector<BuildDiagnostic> diags;
+    bool has_error = false;
+    auto effective = resolve_label_clusters(g, diags, has_error);
+
+    EXPECT_TRUE(has_error);
+    EXPECT_TRUE(effective.empty());
+    bool no_source = false;
+    for (auto const& d : diags)
+    {
+        if (d.message.find("no wired source") != std::string::npos)
+        {
+            no_source = true;
+            EXPECT_EQ(d.node_id, in_id);
+        }
+    }
+    EXPECT_TRUE(no_source);
+}
+
+TEST(LabelResolver, LabelInWithoutLabelOutFlagsError)
+{
+    NodeRegistry nr;
+    piper::register_builtin_nodes(nr);
+    auto g      = make_graph_with_constant(nr);
+    auto src_id = g.nodes().front().id;
+    auto in_id  = g.add_label(LabelKind::In, "solo", Point{ 1.0f, 0.0f });
+    g.add_link(PinRef{ src_id, "out" }, PinRef{ in_id, piper::label_pin_name }, "float");
+
+    std::vector<BuildDiagnostic> diags;
+    bool has_error = false;
+    auto effective = resolve_label_clusters(g, diags, has_error);
+
+    EXPECT_TRUE(has_error);
+    EXPECT_TRUE(effective.empty());
+    bool no_out = false;
+    for (auto const& d : diags)
+    {
+        if (d.message.find("no label_out") != std::string::npos)
+        {
+            no_out = true;
+            EXPECT_EQ(d.node_id, in_id);
+            EXPECT_EQ(d.kind, BuildDiagnostic::Kind::UnresolvedInput);
+        }
+    }
+    EXPECT_TRUE(no_out);
+}
+
 TEST(LabelResolver, SynthesizesOneLinkPerSink)
 {
     NodeRegistry nr;

--- a/tests/engine/pid-t.cc
+++ b/tests/engine/pid-t.cc
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+
+#include "piper/builtin_nodes.h"
+#include "piper/graph.h"
+#include "piper/registry.h"
+#include "piper/stage.h"
+
+#include "piper/engine/builtin_steps.h"
+#include "piper/engine/engine.h"
+#include "piper/engine/external_io.h"
+#include "piper/engine/registry.h"
+
+using piper::Graph;
+using piper::NodeRegistry;
+using piper::PinRef;
+using piper::Point;
+using piper::engine::Engine;
+using piper::engine::StepRegistry;
+
+namespace pid_test
+{
+    // pid<float> with setpoint/measured driven via external inputs and
+    // gains wired to constants; members set from the test.
+    struct Harness
+    {
+        NodeRegistry  nr;
+        StepRegistry  sr;
+        Graph         g;
+        Engine        e;
+        piper::NodeId pid_id{piper::invalid_node_id};
+
+        piper::engine::step::Input<float>* setpoint{nullptr};
+        piper::engine::step::Input<float>* measured{nullptr};
+
+        bool build(char const* kp, char const* ki, char const* kd,
+                   char const* dt, char const* out_min, char const* out_max,
+                   char const* dt_in_value = nullptr)
+        {
+            piper::register_builtin_nodes(nr);
+            piper::engine::register_builtin_steps(sr);
+            g.add_stage(piper::Stage{ "control", 0xFFFFFFFFu });
+
+            auto const* pid_type = nr.find("pid<float>");
+            auto const* cf       = nr.find("constant<float>");
+            auto const* ext_in   = nr.find("external_input<float>");
+
+            pid_id = g.add_node(*pid_type, "pid", "control", Point{});
+            g.set_attr_value(pid_id, "dt",      dt);
+            g.set_attr_value(pid_id, "out_min", out_min);
+            g.set_attr_value(pid_id, "out_max", out_max);
+
+            auto sp_id = g.add_node(*ext_in, "sp", "control", Point{});
+            g.set_attr_value(sp_id, "name", "sp");
+            g.add_link(PinRef{ sp_id, "out" }, PinRef{ pid_id, "setpoint" }, "float");
+
+            auto m_id = g.add_node(*ext_in, "meas", "control", Point{});
+            g.set_attr_value(m_id, "name", "meas");
+            g.add_link(PinRef{ m_id, "out" }, PinRef{ pid_id, "measured" }, "float");
+
+            auto wire_constant = [&](char const* pin, char const* value)
+            {
+                auto c = g.add_node(*cf, pin, "control", Point{});
+                g.set_attr_value(c, "value", value);
+                g.add_link(PinRef{ c, "out" }, PinRef{ pid_id, pin }, "float");
+            };
+            wire_constant("kp", kp);
+            wire_constant("ki", ki);
+            wire_constant("kd", kd);
+            if (dt_in_value != nullptr)
+            {
+                wire_constant("dt_in", dt_in_value);
+            }
+
+            auto res = e.build(g, sr);
+            if (not res.ok)
+            {
+                return false;
+            }
+            setpoint = e.input<float>("sp");
+            measured = e.input<float>("meas");
+            return setpoint != nullptr and measured != nullptr;
+        }
+
+        float out()
+        {
+            return e.step_for(pid_id)->output<float>("out");
+        }
+    };
+}
+
+using pid_test::Harness;
+
+TEST(PidStep, PureProportional)
+{
+    Harness h;
+    ASSERT_TRUE(h.build("2.5", "0.0", "0.0", "0.001", "-1e30", "1e30"));
+
+    h.setpoint->set(1.0f);
+    h.measured->set(0.0f);
+    h.e.tick("control");
+    EXPECT_FLOAT_EQ(h.out(), 2.5f);
+
+    h.setpoint->set(0.4f);
+    h.e.tick("control");
+    EXPECT_FLOAT_EQ(h.out(), 1.0f);
+
+    h.setpoint->set(-2.0f);
+    h.e.tick("control");
+    EXPECT_FLOAT_EQ(h.out(), -5.0f);
+}
+
+TEST(PidStep, OutputClampedToLimits)
+{
+    Harness h;
+    ASSERT_TRUE(h.build("100.0", "0.0", "0.0", "0.001", "-1.5", "1.5"));
+
+    h.setpoint->set(1.0f);
+    h.measured->set(0.0f);
+    h.e.tick("control");
+    EXPECT_FLOAT_EQ(h.out(), 1.5f);
+
+    h.setpoint->set(-1.0f);
+    h.e.tick("control");
+    EXPECT_FLOAT_EQ(h.out(), -1.5f);
+}
+
+TEST(PidStep, AntiWindupFreezesIntegralWhileSaturated)
+{
+    // Pure-I controller, dt = 0.1, output saturates at 0.5. With
+    // conditional integration the integral stops near 0.5; without it
+    // 30 ticks of e=1 would wind it up to ~3.0 and recovery would lag
+    // for dozens of ticks.
+    Harness h;
+    ASSERT_TRUE(h.build("0.0", "1.0", "0.0", "0.1", "-0.5", "0.5"));
+
+    h.setpoint->set(1.0f);
+    h.measured->set(0.0f);
+    for (int i = 0; i < 30; ++i)
+    {
+        h.e.tick("control");
+    }
+    EXPECT_FLOAT_EQ(h.out(), 0.5f);
+
+    // Reverse: error becomes -0.3; the very next tick must drop below
+    // the limit (integral was frozen, not wound up).
+    h.setpoint->set(-0.3f);
+    h.e.tick("control");
+    EXPECT_LT(h.out(), 0.49f) << "recovery delayed: integral wound up while saturated";
+    EXPECT_GT(h.out(), 0.3f);
+}
+
+TEST(PidStep, DtInOverridesDtMember)
+{
+    // Pure-I with dt member 0.001 but dt_in wired to 0.5: one tick of
+    // e=1 integrates 0.5, so out = ki * 0.5. With the member dt the
+    // result would be 0.001.
+    Harness h;
+    ASSERT_TRUE(h.build("0.0", "1.0", "0.0", "0.001", "-1e30", "1e30", "0.5"));
+
+    h.setpoint->set(1.0f);
+    h.measured->set(0.0f);
+    h.e.tick("control");
+    EXPECT_FLOAT_EQ(h.out(), 0.5f);
+}

--- a/tests/migrate/CMakeLists.txt
+++ b/tests/migrate/CMakeLists.txt
@@ -11,3 +11,47 @@ target_link_libraries(piper_migrate_test PRIVATE
 gtest_discover_tests(piper_migrate_test
     PROPERTIES TIMEOUT 60
 )
+
+# ---- piper-migrate CLI end-to-end ----
+set(MIGRATE_CLI_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/cli)
+set(MIGRATE_DATA        ${CMAKE_CURRENT_SOURCE_DIR}/data)
+
+add_test(NAME migrate_cli.unknown_type_aborts_without_output
+    COMMAND ${CMAKE_COMMAND}
+        -DMIGRATE_BIN=$<TARGET_FILE:piper_migrate_cli>
+        -DINPUT=${MIGRATE_DATA}/v1_unknown_type.json
+        -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${MIGRATE_CLI_SCRIPTS}/unknown_type.cmake
+)
+
+add_test(NAME migrate_cli.dry_run_writes_nothing
+    COMMAND ${CMAKE_COMMAND}
+        -DMIGRATE_BIN=$<TARGET_FILE:piper_migrate_cli>
+        -DINPUT=${MIGRATE_DATA}/v1_good.json
+        -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${MIGRATE_CLI_SCRIPTS}/dry_run.cmake
+)
+
+add_test(NAME migrate_cli.already_migrated_refused_input_intact
+    COMMAND ${CMAKE_COMMAND}
+        -DMIGRATE_BIN=$<TARGET_FILE:piper_migrate_cli>
+        -DINPUT=${MIGRATE_DATA}/already_v3.piper
+        -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${MIGRATE_CLI_SCRIPTS}/already_migrated.cmake
+)
+
+add_test(NAME migrate_cli.default_output_self_refused_input_intact
+    COMMAND ${CMAKE_COMMAND}
+        -DMIGRATE_BIN=$<TARGET_FILE:piper_migrate_cli>
+        -DINPUT=${MIGRATE_DATA}/v1_good.json
+        -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${MIGRATE_CLI_SCRIPTS}/default_output_self.cmake
+)
+
+set_tests_properties(
+    migrate_cli.unknown_type_aborts_without_output
+    migrate_cli.dry_run_writes_nothing
+    migrate_cli.already_migrated_refused_input_intact
+    migrate_cli.default_output_self_refused_input_intact
+    PROPERTIES TIMEOUT 60
+)

--- a/tests/migrate/cli/already_migrated.cmake
+++ b/tests/migrate/cli/already_migrated.cmake
@@ -1,0 +1,29 @@
+# Feeding an already-migrated v2/v3 .piper file: non-zero exit, no
+# output written, original file byte-identical afterwards. The fixture
+# is copied to the binary dir so the source tree is never at risk.
+# Args: MIGRATE_BIN, INPUT, WORK_DIR
+set(work_input "${WORK_DIR}/already_v3_copy.piper")
+set(out        "${WORK_DIR}/already_v3_out.piper")
+file(REMOVE "${work_input}" "${out}")
+configure_file("${INPUT}" "${work_input}" COPYONLY)
+
+execute_process(
+    COMMAND "${MIGRATE_BIN}" "${work_input}" -o "${out}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out_text
+    ERROR_VARIABLE  err_text
+)
+if(rc EQUAL 0)
+    message(FATAL_ERROR "expected non-zero exit on already-migrated input")
+endif()
+if(EXISTS "${out}")
+    message(FATAL_ERROR "output file was written for already-migrated input")
+endif()
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E compare_files "${INPUT}" "${work_input}"
+    RESULT_VARIABLE same
+)
+if(NOT same EQUAL 0)
+    message(FATAL_ERROR "input file was modified")
+endif()

--- a/tests/migrate/cli/default_output_self.cmake
+++ b/tests/migrate/cli/default_output_self.cmake
@@ -1,0 +1,26 @@
+# A valid V1 file named *.piper with no -o: the default output
+# (input with .piper extension) resolves to the input path itself.
+# Expect non-zero exit and the input left intact. The fixture is
+# copied to the binary dir so the source tree is never at risk.
+# Args: MIGRATE_BIN, INPUT, WORK_DIR
+set(work_input "${WORK_DIR}/self.piper")
+file(REMOVE "${work_input}")
+configure_file("${INPUT}" "${work_input}" COPYONLY)
+
+execute_process(
+    COMMAND "${MIGRATE_BIN}" "${work_input}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out_text
+    ERROR_VARIABLE  err_text
+)
+if(rc EQUAL 0)
+    message(FATAL_ERROR "expected non-zero exit when default output is the input path")
+endif()
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E compare_files "${INPUT}" "${work_input}"
+    RESULT_VARIABLE same
+)
+if(NOT same EQUAL 0)
+    message(FATAL_ERROR "input file was overwritten")
+endif()

--- a/tests/migrate/cli/dry_run.cmake
+++ b/tests/migrate/cli/dry_run.cmake
@@ -1,0 +1,17 @@
+# --dry-run on a valid V1 input: exit 0, no output file written.
+# Args: MIGRATE_BIN, INPUT, WORK_DIR
+set(out "${WORK_DIR}/dry_run_out.piper")
+file(REMOVE "${out}")
+
+execute_process(
+    COMMAND "${MIGRATE_BIN}" "${INPUT}" --dry-run -o "${out}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out_text
+    ERROR_VARIABLE  err_text
+)
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "expected exit code 0, got '${rc}'\nstderr: ${err_text}")
+endif()
+if(EXISTS "${out}")
+    message(FATAL_ERROR "--dry-run wrote an output file")
+endif()

--- a/tests/migrate/cli/unknown_type.cmake
+++ b/tests/migrate/cli/unknown_type.cmake
@@ -1,0 +1,17 @@
+# V1 input with an unknown node type: exit 1, no output file written.
+# Args: MIGRATE_BIN, INPUT, WORK_DIR
+set(out "${WORK_DIR}/unknown_type_out.piper")
+file(REMOVE "${out}")
+
+execute_process(
+    COMMAND "${MIGRATE_BIN}" "${INPUT}" -o "${out}"
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out_text
+    ERROR_VARIABLE  err_text
+)
+if(NOT rc EQUAL 1)
+    message(FATAL_ERROR "expected exit code 1, got '${rc}'\nstderr: ${err_text}")
+endif()
+if(EXISTS "${out}")
+    message(FATAL_ERROR "output file was written despite critical diagnostics")
+endif()

--- a/tests/migrate/data/already_v3.piper
+++ b/tests/migrate/data/already_v3.piper
@@ -1,0 +1,4 @@
+{
+  "version": 3,
+  "pipelines": []
+}

--- a/tests/migrate/data/v1_good.json
+++ b/tests/migrate/data/v1_good.json
@@ -1,0 +1,12 @@
+{
+    "demo": {
+        "Stages": ["control"],
+        "Nodes": {
+            "src":  { "type": "constant<float>", "stage": "control", "value": "1.5" },
+            "sink": { "type": "probe<float>",    "stage": "control" }
+        },
+        "Links": [
+            { "from": "src", "out": "out", "to": "sink", "in": "in", "type": "float" }
+        ]
+    }
+}

--- a/tests/migrate/data/v1_unknown_type.json
+++ b/tests/migrate/data/v1_unknown_type.json
@@ -1,0 +1,9 @@
+{
+    "demo": {
+        "Stages": ["control"],
+        "Nodes": {
+            "mystery": { "type": "flux_capacitor", "stage": "control" }
+        },
+        "Links": []
+    }
+}

--- a/tools/setup/version.sh
+++ b/tools/setup/version.sh
@@ -1,14 +1,34 @@
 #!/bin/bash
+set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Tag scheme: vX.Y.Z or vX.Y.Z-rcN. Off-scheme -> 0.0.0 in both files.
+# CMake needs strict X[.Y[.Z[.T]]], so rc rides the tweak slot: X.Y.Z.N.
 VERSION="0.0.0"
+CMAKE_VERSION="0.0.0"
 
-if git rev-parse --git-dir > /dev/null 2>&1; then
-    TAG=$(git describe --tags --exact-match 2>/dev/null)
+if git -C "$ROOT_DIR" rev-parse --git-dir > /dev/null 2>&1; then
+    TAG=$(git -C "$ROOT_DIR" describe --tags --exact-match 2>/dev/null || true)
 
-    if [[ -n "$TAG" ]]; then
+    if [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-rc([0-9]+))?$ ]]; then
         VERSION="$TAG"
+        BASE="${BASH_REMATCH[1]}"
+        RC="${BASH_REMATCH[3]:-}"
+        if [[ -n "$RC" ]]; then
+            CMAKE_VERSION="${BASE}.${RC}"
+        else
+            CMAKE_VERSION="$BASE"
+        fi
     fi
 fi
 
-export VERSION
-echo "VERSION set to: $VERSION"
+# Anchor to the actual version lines (not the '0.0.0' literal) so re-runs on
+# an already-substituted tree overwrite instead of no-op'ing.
+sed -i -E "s/^version = \".+\"$/version = \"${VERSION}\"/" \
+    "$ROOT_DIR/pyproject.toml"
+sed -i -E "s/^project\(piper VERSION [^ )]+/project(piper VERSION ${CMAKE_VERSION}/" \
+    "$ROOT_DIR/CMakeLists.txt"
+
+echo "VERSION set to: $VERSION (CMake: $CMAKE_VERSION)"

--- a/vendor/imgui_backends/CMakeLists.txt
+++ b/vendor/imgui_backends/CMakeLists.txt
@@ -14,7 +14,7 @@ set(GLFW_LIBRARY_TYPE   "STATIC" CACHE STRING "" FORCE)
 include(FetchContent)
 FetchContent_Declare(glfw
     GIT_REPOSITORY https://github.com/glfw/glfw.git
-    GIT_TAG        3.4
+    GIT_TAG        7b6aead9fb88b3623e3b3725ebb42670cbe4c579 # tag 3.4
 )
 FetchContent_MakeAvailable(glfw)
 

--- a/vendor/imgui_backends/LICENSE.txt
+++ b/vendor/imgui_backends/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2026 Omar Cornut
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
  Data loss & crashes:
  - serialize: parse labels before links so label-routed wires survive save/load
  - engine: fail build with MissingInput/DuplicateInputWiring instead of throwing at tick
  - app: wrap engine play()/tick() so a compute exception stops the engine, not the editor
  - migrate: refuse to overwrite input, reject already-migrated and empty-result files

  Core robustness:
  - contain malformed JSON fields as per-item diagnostics instead of leaking json::type_error
  - reject id 0 / negative ids; guard reserve_ids_above overflow
  - throw on non-array "pipelines"; validate/clamp theme grid spacing and font size
  - fix AddStage/AddModeProfile undo deleting pre-existing entries
  - repair_label_clusters honors first-by-id; registry heterogeneous lookup; add Lint kind

  Memory safety (Python bindings):
  - find_node/find_link/find_attr return copies; engine handles are shared_ptr surviving build()
  - Step accessors throw instead of segfaulting; Stage keeps name alive; complete Diagnostic.Kind
  - guard external-IO downcast (FactoryTypeMismatch); delete Engine copy/move; probe sink steps

  Performance:
  - cache node geometry per frame (kills O(pins^2) CalcTextSize); cull off-screen links
  - debounce live-engine rebuild; pre-resolve per-stage blocks; drop per-frame exception throws

  Build/packaging/docs/CI:
  - fix README quick start; declare conan dep; fatal setup failure
  - install rules + cmake.install packaging + version; gate IPO out of package builds
  - BUILD_TESTS without BUILD_APP; pin GLFW commit; MIT license notices
  - add GitHub Actions CI running the full suite